### PR TITLE
feat: add diagnostic logging to search pipeline

### DIFF
--- a/reverse_image_search_bot/commands/search.py
+++ b/reverse_image_search_bot/commands/search.py
@@ -61,6 +61,8 @@ async def file_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, messa
         await message.reply_text(t("search.files.banned", L))
         return
 
+    chat_id = message.chat_id
+    logger.info("file_handler: start user=%s chat=%s msg=%s", user.id, chat_id, message.message_id)
     await context.bot.send_chat_action(chat_id=message.chat_id, action=ChatAction.TYPING)
 
     attachment = message.effective_attachment
@@ -136,6 +138,7 @@ async def file_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, messa
         try:
             chat_config = ChatConfig(update.effective_chat.id)
             if chat_config.auto_search_enabled:
+                logger.info("file_handler: starting best_match user=%s chat=%s", user.id, chat_id)
                 await best_match(update, context, image_url, general_done)
             else:
                 await general_task
@@ -144,6 +147,8 @@ async def file_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, messa
             with contextlib.suppress(asyncio.CancelledError):
                 await general_task
             raise
+        finally:
+            logger.info("file_handler: done user=%s chat=%s msg=%s", user.id, chat_id, message.message_id)
 
     except Exception:
         await message.reply_text(t("search.generic_error", L))
@@ -335,6 +340,13 @@ async def _best_match_search(
     match_found = False
 
     metrics.concurrent_searches.inc()
+    concurrent_val = metrics.concurrent_searches._value.get()
+    logger.info(
+        "_best_match_search: start chat=%s concurrent=%s engines=%s",
+        message.chat_id,
+        concurrent_val,
+        [e.name for e in search_engines],
+    )
     _reply_to_msg_id: int | None = message.message_id
 
     engine_start_times: dict[asyncio.Task, float] = {}
@@ -481,6 +493,7 @@ async def _best_match_search(
         for task in pending:
             task.cancel()
         metrics.concurrent_searches.dec()
+        logger.info("_best_match_search: done chat=%s", message.chat_id)
 
     metrics.search_results_total.labels(has_results=str(match_found).lower()).inc()
     return match_found

--- a/reverse_image_search_bot/commands/utils.py
+++ b/reverse_image_search_bot/commands/utils.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import io
+import logging
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+from time import time
 
 from PIL import Image
 from telegram import Animation, Document, PhotoSize, Sticker, Video
@@ -13,6 +15,8 @@ from yarl import URL
 from reverse_image_search_bot.i18n import t
 from reverse_image_search_bot.uploaders import uploader
 from reverse_image_search_bot.utils import upload_file
+
+logger = logging.getLogger(__name__)
 
 last_used: dict[int, float] = {}
 
@@ -118,14 +122,19 @@ async def video_to_url(attachment: Document | Video | Animation | Sticker) -> UR
             return await image_to_url(attachment.thumbnail)
         raise ValueError(t("search.files.video_too_large"))
 
+    t0 = time()
+    logger.info("video_to_url: downloading file %s", attachment.file_unique_id)
     video_file = await attachment.get_file()
     with NamedTemporaryFile(suffix=".mp4") as tmp:
         await video_file.download_to_drive(tmp.name)
+        logger.info("video_to_url: downloaded in %.1fs, extracting frame", time() - t0)
         loop = asyncio.get_running_loop()
         frame_bytes = await loop.run_in_executor(_process_executor, _extract_video_frame, tmp.name)
 
     with io.BytesIO(frame_bytes) as file:
-        return upload_file(file, filename)
+        url = upload_file(file, filename)
+    logger.info("video_to_url: done in %.1fs -> %s", time() - t0, url)
+    return url
 
 
 async def image_to_url(attachment: PhotoSize | Sticker | Document) -> URL:
@@ -140,12 +149,17 @@ async def image_to_url(attachment: PhotoSize | Sticker | Document) -> URL:
     if uploader.file_exists(filename):
         return uploader.get_url(filename)
 
+    t0 = time()
+    logger.info("image_to_url: downloading file %s", attachment.file_unique_id)
     photo_file = await attachment.get_file()
     with io.BytesIO() as file:
         await photo_file.download_to_memory(file)
+        logger.info("image_to_url: downloaded in %.1fs", time() - t0)
         if extension != "jpg":
             file.seek(0)
             with Image.open(file) as image:
                 file.seek(0)
                 image.save(file, extension)
-        return upload_file(file, filename)
+        url = upload_file(file, filename)
+    logger.info("image_to_url: done in %.1fs -> %s", time() - t0, url)
+    return url

--- a/reverse_image_search_bot/engines/saucenao.py
+++ b/reverse_image_search_bot/engines/saucenao.py
@@ -153,7 +153,9 @@ class SauceNaoEngine(GenericRISEngine):
             quote_plus(str(url)), f"&api_key={SAUCENAO_API}" if SAUCENAO_API else ""
         )
         try:
+            self.logger.info("Waiting for SauceNAO lock for %s", url)
             async with self._lock:
+                self.logger.info("Acquired SauceNAO lock, requesting %s", url)
                 response = await self._http_client.get(api_link, timeout=5)
         except httpx.ConnectError as e:
             raise SearchError("Error connecting to SauceNAO API") from e


### PR DESCRIPTION
## Problem

The bot became unresponsive for hours (stuck at 16 concurrent searches). No logging exists to diagnose what caused the hang.

## Changes

Diagnostic logging (all INFO level) added to:
- `file_handler`: entry/exit with user, chat, message id
- `best_match`: start with user/chat info  
- `_best_match_search`: start/end with concurrent search count and engine list
- `image_to_url` / `video_to_url`: download and upload timing
- SauceNAO: lock wait/acquire events

No behavioral changes — diagnostics only.