### PR TITLE
Fix all ty diagnostics in test suite

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -19,6 +19,7 @@ from reverse_image_search_bot.commands import (
     file_handler,
     settings_callback_handler,
 )
+from reverse_image_search_bot.engines.types import MetaData
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -52,7 +53,7 @@ def _button_texts(keyboard: InlineKeyboardMarkup) -> list[str]:
     return [btn.text for btn in _flat_buttons(keyboard)]
 
 
-def _button_callbacks(keyboard: InlineKeyboardMarkup) -> list[str]:
+def _button_callbacks(keyboard: InlineKeyboardMarkup) -> list[object | None]:
     return [btn.callback_data for btn in _flat_buttons(keyboard)]
 
 
@@ -137,7 +138,7 @@ class TestSettingsEnginesKeyboard:
         assert any("SauceNAO" in t for t in texts)
         assert any("AnimeTrace" in t for t in texts)
         # All should have the auto_search_engine callback prefix
-        assert any(cb.startswith("settings:toggle:auto_search_engine:") for cb in callbacks)
+        assert any(isinstance(cb, str) and cb.startswith("settings:toggle:auto_search_engine:") for cb in callbacks)
         # Last row should be ← Back
         assert texts[-1] == "← Back"
         assert callbacks[-1] == "settings:back"
@@ -289,9 +290,9 @@ class TestTrackEngineResult:
 class TestBuildReply:
     def test_basic_reply(self):
         result = {"Title": "My Image", "Artist": "Nobody"}
-        meta = {
+        meta: MetaData = {
             "provider": "SauceNAO",
-            "provider_url": "https://saucenao.com",
+            "provider_url": URL("https://saucenao.com"),
         }
         reply, media = build_reply(result, meta)
 
@@ -304,9 +305,9 @@ class TestBuildReply:
 
     def test_with_similarity(self):
         result = {"Title": "Test"}
-        meta = {
+        meta: MetaData = {
             "provider": "SauceNAO",
-            "provider_url": "https://saucenao.com",
+            "provider_url": URL("https://saucenao.com"),
             "similarity": 92.5,
         }
         reply, _media = build_reply(result, meta)
@@ -314,9 +315,9 @@ class TestBuildReply:
 
     def test_with_provided_via(self):
         result = {"Title": "Test"}
-        meta = {
+        meta: MetaData = {
             "provider": "SauceNAO",
-            "provider_url": "https://saucenao.com",
+            "provider_url": URL("https://saucenao.com"),
             "provided_via": "Anilist",
         }
         reply, _media = build_reply(result, meta)
@@ -324,20 +325,20 @@ class TestBuildReply:
 
     def test_with_provided_via_url(self):
         result = {"Title": "Test"}
-        meta = {
+        meta: MetaData = {
             "provider": "SauceNAO",
-            "provider_url": "https://saucenao.com",
+            "provider_url": URL("https://saucenao.com"),
             "provided_via": "Anilist",
-            "provided_via_url": "https://anilist.co",
+            "provided_via_url": URL("https://anilist.co"),
         }
         reply, _media = build_reply(result, meta)
         assert '<a href="https://anilist.co"><b >Anilist</b></a>' in reply
 
     def test_thumbnail_url_becomes_hidden_anchor(self):
         result = {"Title": "Test"}
-        meta = {
+        meta: MetaData = {
             "provider": "Test",
-            "provider_url": "https://test.com",
+            "provider_url": URL("https://test.com"),
             "thumbnail": URL("https://img.test.com/thumb.jpg"),
         }
         reply, media = build_reply(result, meta)
@@ -347,9 +348,9 @@ class TestBuildReply:
     def test_thumbnail_list_becomes_media_group(self):
         urls = [URL("https://img.test.com/1.jpg"), URL("https://img.test.com/2.jpg")]
         result = {"Title": "Test"}
-        meta = {
+        meta: MetaData = {
             "provider": "Test",
-            "provider_url": "https://test.com",
+            "provider_url": URL("https://test.com"),
             "thumbnail": urls,
         }
         _reply, media = build_reply(result, meta)
@@ -359,7 +360,7 @@ class TestBuildReply:
 
     def test_set_value_in_result(self):
         result = {"Tags": {"cat", "dog"}}
-        meta = {"provider": "Test", "provider_url": "https://test.com"}
+        meta: MetaData = {"provider": "Test", "provider_url": URL("https://test.com")}
         reply, _media = build_reply(result, meta)
         # Sets are comma-joined (order may vary)
         assert "cat" in reply
@@ -367,14 +368,14 @@ class TestBuildReply:
 
     def test_list_value_in_result(self):
         result = {"Tags": ["cat", "dog"]}
-        meta = {"provider": "Test", "provider_url": "https://test.com"}
+        meta: MetaData = {"provider": "Test", "provider_url": URL("https://test.com")}
         reply, _media = build_reply(result, meta)
         assert "<code >cat</code>" in reply
         assert "<code >dog</code>" in reply
 
     def test_html_escaping(self):
         result = {"Title": "<script>alert('xss')</script>"}
-        meta = {"provider": "Test", "provider_url": "https://test.com"}
+        meta: MetaData = {"provider": "Test", "provider_url": URL("https://test.com")}
         reply, _media = build_reply(result, meta)
         assert "<script>" not in reply
         assert "&lt;script&gt;" in reply

--- a/tests/test_config_chat_config.py
+++ b/tests/test_config_chat_config.py
@@ -1,5 +1,6 @@
 """Tests for reverse_image_search_bot.config.chat_config."""
 
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -15,7 +16,7 @@ def _isolated_chat_config():
     """
     from reverse_image_search_bot.config.chat_config import ChatConfig
 
-    real_cls = ChatConfig.__closure__[0].cell_contents
+    real_cls = cast(Any, ChatConfig).__closure__[0].cell_contents
     real_cls._loaded_chats = {}
     yield
     real_cls._loaded_chats = {}
@@ -110,7 +111,7 @@ class TestSingleChatDecorator:
         ):
             from reverse_image_search_bot.config.chat_config import ChatConfig
 
-            real_cls = ChatConfig.__closure__[0].cell_contents
+            real_cls = cast(Any, ChatConfig).__closure__[0].cell_contents
             real_cls._loaded_chats = {}
 
             for idx in range(500):
@@ -143,7 +144,7 @@ class TestSingleChatDecorator:
         ):
             from reverse_image_search_bot.config.chat_config import ChatConfig
 
-            real_cls = ChatConfig.__closure__[0].cell_contents
+            real_cls = cast(Any, ChatConfig).__closure__[0].cell_contents
             # Delete _loaded_chats to trigger the hasattr branch
             if hasattr(real_cls, "_loaded_chats"):
                 delattr(real_cls, "_loaded_chats")

--- a/tests/test_config_db.py
+++ b/tests/test_config_db.py
@@ -91,6 +91,7 @@ class TestSaveAndLoad:
         save_config(100, {"show_buttons": True})
         save_field(100, "show_buttons", False)
         loaded = load_config(100)
+        assert loaded is not None
         assert loaded["show_buttons"] is False
 
     def test_save_field_creates_row(self):
@@ -113,6 +114,7 @@ class TestSaveAndLoad:
         engines = ["SauceNAO", "Google", "Yandex"]
         save_config(400, {"auto_search_engines": engines})
         loaded = load_config(400)
+        assert loaded is not None
         assert loaded["auto_search_engines"] == engines
 
     def test_engine_empty_counts_roundtrip(self):
@@ -121,6 +123,7 @@ class TestSaveAndLoad:
         counts = {"SauceNAO": 3, "Yandex": 1}
         save_config(500, {"engine_empty_counts": counts})
         loaded = load_config(500)
+        assert loaded is not None
         assert loaded["engine_empty_counts"] == counts
 
 

--- a/tests/test_data_providers.py
+++ b/tests/test_data_providers.py
@@ -1,5 +1,6 @@
 """Tests for reverse_image_search_bot.engines.data_providers — all providers mocked HTTP."""
 
+import re
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -443,8 +444,10 @@ class TestBooruProvider:
         # The id_reg uses re.match which anchors at start — can never match a full URL.
         # This is dead code (line 124). Verify the regex itself works if it matched:
         matcher = provider.urls["gelbooru"]["id_reg"]
-        assert matcher.match("id=67890") is not None
-        assert matcher.match("id=67890").groups()[0] == "67890"
+        assert isinstance(matcher, re.Pattern)
+        match = matcher.match("id=67890")
+        assert match is not None
+        assert match.groups()[0] == "67890"
 
 
 # ---------------------------------------------------------------------------
@@ -915,8 +918,10 @@ class TestMangadexProvider:
         with patch.object(provider._http_client, "get", new_callable=AsyncMock, return_value=mock_resp):
             result, _meta = await provider.provide(manga_id="trunc-test")
 
-        assert result["Description"].endswith("...")
-        assert len(result["Description"]) == 150
+        desc = result["Description"]
+        assert isinstance(desc, str)
+        assert desc.endswith("...")
+        assert len(desc) == 150
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_engines_animetrace.py
+++ b/tests/test_engines_animetrace.py
@@ -119,6 +119,7 @@ class TestAnilistPost:
         with patch("reverse_image_search_bot.engines.animetrace._anilist_client") as mock_client:
             mock_client.post = AsyncMock(return_value=mock_resp)
             result = await _anilist_post({"query": "test", "variables": {}})
+        assert result is not None
         assert result["data"]["Character"]["name"]["full"] == "Test"
 
     async def test_429_retries(self):
@@ -375,8 +376,10 @@ class TestAnimeTraceExtract:
             result, _meta = await engine._extract([mock_item])
 
         assert "Also possible" in result
-        assert "Alt1 EN" in result["Also possible"]
-        assert "Alt2 EN" in result["Also possible"]
+        also_possible = result["Also possible"]
+        assert isinstance(also_possible, str)
+        assert "Alt1 EN" in also_possible
+        assert "Alt2 EN" in also_possible
 
     async def test_single_item_with_buttons_from_anilist(self):
         """Test that buttons from anilist are combined with character button."""
@@ -409,9 +412,10 @@ class TestAnimeTraceExtract:
 
         assert "buttons" in meta
         # Should have char button + anilist button
-        assert len(meta["buttons"]) == 2
-        assert any("character/42" in b.url for b in meta["buttons"])
-        assert any("anilist.co" in b.url for b in meta["buttons"])
+        buttons = meta["buttons"]
+        assert len(buttons) == 2
+        assert any(b.url and "character/42" in b.url for b in buttons)
+        assert any(b.url and "anilist.co" in b.url for b in buttons)
 
     async def test_single_item_no_media_id(self):
         _anilist_resolve_cache.clear()
@@ -433,7 +437,7 @@ class TestAnimeTraceExtract:
 
         assert result["Character"] == "Solo EN"
         assert "buttons" in meta
-        assert any("character/5" in b.url for b in meta["buttons"])
+        assert any(b.url and "character/5" in b.url for b in meta["buttons"])
 
     async def test_multiple_confident_items(self):
         _anilist_resolve_cache.clear()
@@ -454,8 +458,10 @@ class TestAnimeTraceExtract:
             result, _meta = await engine._extract(items)
 
         assert "Characters" in result
-        assert "Char1 EN" in result["Characters"]
-        assert "Char2 EN" in result["Characters"]
+        characters = result["Characters"]
+        assert isinstance(characters, str)
+        assert "Char1 EN" in characters
+        assert "Char2 EN" in characters
 
     async def test_multiple_items_no_characters(self):
         _anilist_resolve_cache.clear()

--- a/tests/test_engines_generic.py
+++ b/tests/test_engines_generic.py
@@ -7,6 +7,7 @@ from telegram import InlineKeyboardButton
 from yarl import URL
 
 from reverse_image_search_bot.engines.generic import GenericRISEngine, PreWorkEngine
+from reverse_image_search_bot.engines.types import MetaData
 
 
 class TestGenericRISEngine:
@@ -78,14 +79,14 @@ class TestCleanMetaData:
         invalid = MagicMock(spec=InlineKeyboardButton)
         invalid.url = "not-a-url"
 
-        meta = {"buttons": [valid, invalid]}
+        meta: MetaData = {"buttons": [valid, invalid]}
         result = engine._clean_meta_data(meta)
         assert valid in result["buttons"]
         assert invalid not in result["buttons"]
 
     def test_empty_buttons(self):
         engine = GenericRISEngine()
-        meta = {"buttons": []}
+        meta: MetaData = {"buttons": []}
         result = engine._clean_meta_data(meta)
         assert result["buttons"] == []
 

--- a/tests/test_engines_saucenao.py
+++ b/tests/test_engines_saucenao.py
@@ -412,7 +412,7 @@ class TestDefaultProvider:
         result, meta = engine._default_provider(data)
         assert result["Poster"] == "Elonmusk"
         buttons = meta.get("buttons", [])
-        assert any("twitter.com/elonmusk" in b.url for b in buttons)
+        assert any(b.url and "twitter.com/elonmusk" in b.url for b in buttons)
 
     def test_generic_field_fallback(self):
         engine = SauceNaoEngine()

--- a/tests/test_engines_trace.py
+++ b/tests/test_engines_trace.py
@@ -13,7 +13,6 @@ def engine():
     e = TraceEngine()
     e._best_match_cache.clear()
     e._use_api_key = False
-    e.limit_reached = None
     return e
 
 


### PR DESCRIPTION
## Summary

All 33 \`ty\` diagnostics on \`master\` lived in the test suite. This PR brings the type-checker output to **zero** without touching any production code.

ty count: **33 → 0**. Test count: **432 passing → 432 passing**. Ruff: clean. No new \`# type: ignore\`.

## Changes by file

- **\`test_config_db.py\`** — \`assert loaded is not None\` before subscripting \`load_config(...)\` (3x)
- **\`test_config_chat_config.py\`** — \`cast(Any, ChatConfig).__closure__\` for the closure introspection used by the \`_isolated_chat_config\` fixture; ChatConfig is a function after the \`@single_chat\` decorator, not a class, but ty correctly sees it as a class (3x)
- **\`test_commands.py\`** —
  - Annotate \`meta\` dict literals in \`TestBuildReply\` as \`MetaData\` TypedDict (9x)
  - Wrap \`provider_url\` / \`provided_via_url\` string literals in \`URL(...)\` to match the declared \`MetaData\` type
  - Loosen \`_button_callbacks\` return type from \`list[str]\` to \`list[object | None]\` to match \`InlineKeyboardButton.callback_data\`
  - \`isinstance(cb, str)\` guard before calling \`.startswith(...)\`
- **\`test_engines_generic.py\`** — Annotate \`meta\` dicts as \`MetaData\` (2x)
- **\`test_data_providers.py\`** — \`isinstance(matcher, re.Pattern)\` narrows the regex lookup; \`isinstance(desc, str)\` narrows \`result['Description']\` before \`.endswith\` / \`len\`
- **\`test_engines_animetrace.py\`** — \`assert result is not None\` before subscripting; narrow union-typed \`result[...]\` values to \`str\` via \`isinstance\`; guard \`b.url\` against \`None\` before \`in\` checks
- **\`test_engines_saucenao.py\`** — Same \`b.url\` None guard
- **\`test_engines_trace.py\`** — Drop \`e.limit_reached = None\` from the engine fixture; \`TraceEngine\` has no such attribute (only \`SauceNaoEngine\` does — leftover from a copy-paste)

## Verification

- \`env -u VIRTUAL_ENV uv run ty check\` → **All checks passed!**
- \`env -u VIRTUAL_ENV uv run pytest\` → **432 passed, 1 warning** (unrelated \`pixivpy3\` warning)
- \`env -u VIRTUAL_ENV uv run ruff check .\` → clean
- \`env -u VIRTUAL_ENV uv run ruff format --check .\` → clean