### PR TITLE
Triage Bugsink noise: transient errors, timeouts, deleted-message handling

### DIFF
--- a/reverse_image_search_bot/bot.py
+++ b/reverse_image_search_bot/bot.py
@@ -15,6 +15,7 @@ from telegram.ext import (
     CommandHandler,
     ContextTypes,
     ConversationHandler,
+    Defaults,
     MessageHandler,
     PicklePersistence,
     filters,
@@ -237,6 +238,9 @@ def main():
     builder = Application.builder().token(settings.TELEGRAM_API_TOKEN)
     builder.persistence(persistence)
     builder.concurrent_updates(settings.CONCURRENT_UPDATES)
+    # Users delete their message mid-search — send the reply standalone
+    # instead of failing with "Message to be replied not found".
+    builder.defaults(Defaults(allow_sending_without_reply=True))
     builder.post_init(post_init)
     app = builder.build()
     application = app

--- a/reverse_image_search_bot/commands/search.py
+++ b/reverse_image_search_bot/commands/search.py
@@ -27,7 +27,7 @@ from yarl import URL
 from reverse_image_search_bot import metrics
 from reverse_image_search_bot.config import ChatConfig
 from reverse_image_search_bot.engines import engines
-from reverse_image_search_bot.engines.errors import EngineError, RateLimitError
+from reverse_image_search_bot.engines.errors import EngineError, RateLimitError, is_transient
 from reverse_image_search_bot.engines.generic import GenericRISEngine, PreWorkEngine
 from reverse_image_search_bot.engines.types import MetaData, ResultData
 from reverse_image_search_bot.i18n import lang as get_lang
@@ -278,19 +278,22 @@ async def best_match(
         if chat_config.failures_in_a_row > 4 and chat_config.auto_search_enabled:
             chat_config.auto_search_enabled = False
             await message.reply_text(t("search.auto_disable.message", L))
-        await search_message.edit_text(
-            t("search.no_results", L, engines=engines_used_html),
-            ParseMode.HTML,
-        )
+        # ponytail: user may have deleted the "searching…" message mid-search
+        with contextlib.suppress(BadRequest):
+            await search_message.edit_text(
+                t("search.no_results", L, engines=engines_used_html),
+                ParseMode.HTML,
+            )
     else:
         chat_config.failures_in_a_row = 0
         result_text = t("search.results_found", L, engines=engines_used_html)
         if not chat_config.auto_search_enabled:
             result_text += t("search.results_found_reenable", L)
-        await search_message.edit_text(
-            result_text,
-            ParseMode.HTML,
-        )
+        with contextlib.suppress(BadRequest):
+            await search_message.edit_text(
+                result_text,
+                ParseMode.HTML,
+            )
 
 
 _AUTO_DISABLE_THRESHOLD = 5
@@ -476,9 +479,16 @@ async def _best_match_search(
                         )
                 except EngineError as engine_err:
                     metrics.provider_results_total.labels(provider=engine.name, status="error").inc()
-                    logger.exception("Engine error [%s]", engine.name, exc_info=engine_err)
+                    if getattr(engine_err, "report", True) and not is_transient(engine_err):
+                        logger.exception("Engine error [%s]", engine.name, exc_info=engine_err)
+                    else:
+                        # Transient network blip or muted known-broken upstream — keep out of error tracking.
+                        logger.info("Engine error (not reported) [%s]: %s", engine.name, engine_err)
                 except Exception as error:
                     metrics.provider_results_total.labels(provider=engine.name, status="error").inc()
+                    if is_transient(error):
+                        logger.info("Transient error [%s]: %s", engine.name, type(error).__name__)
+                        continue
                     user = update.effective_user
                     user_info = f"{user.full_name} (tg://user?id={user.id})" if user else "Unknown"
                     logger.error(

--- a/reverse_image_search_bot/commands/utils.py
+++ b/reverse_image_search_bot/commands/utils.py
@@ -42,6 +42,9 @@ _LANG_NAMES: dict[str, str] = {
 # Telegram Bot API file download limit (20 MB)
 MAX_TELEGRAM_FILE_SIZE = 20 * 1024 * 1024
 
+# getFile/download timeout — PTB's 5s default read timeout is too tight for media.
+_FILE_TIMEOUT = 10.0
+
 
 def _extract_video_frame(video_path: str) -> bytes:
     """Extract the first frame from a video as JPEG bytes. Runs in a separate process."""
@@ -124,9 +127,10 @@ async def video_to_url(attachment: Document | Video | Animation | Sticker) -> UR
 
     t0 = time()
     logger.info("video_to_url: downloading file %s", attachment.file_unique_id)
-    video_file = await attachment.get_file()
+    # PTB's default 5s read timeout is too tight for media — bump to 10s max.
+    video_file = await attachment.get_file(read_timeout=_FILE_TIMEOUT, connect_timeout=_FILE_TIMEOUT)
     with NamedTemporaryFile(suffix=".mp4") as tmp:
-        await video_file.download_to_drive(tmp.name)
+        await video_file.download_to_drive(tmp.name, read_timeout=_FILE_TIMEOUT, connect_timeout=_FILE_TIMEOUT)
         logger.info("video_to_url: downloaded in %.1fs, extracting frame", time() - t0)
         loop = asyncio.get_running_loop()
         frame_bytes = await loop.run_in_executor(_process_executor, _extract_video_frame, tmp.name)
@@ -151,9 +155,9 @@ async def image_to_url(attachment: PhotoSize | Sticker | Document) -> URL:
 
     t0 = time()
     logger.info("image_to_url: downloading file %s", attachment.file_unique_id)
-    photo_file = await attachment.get_file()
+    photo_file = await attachment.get_file(read_timeout=_FILE_TIMEOUT, connect_timeout=_FILE_TIMEOUT)
     with io.BytesIO() as file:
-        await photo_file.download_to_memory(file)
+        await photo_file.download_to_memory(file, read_timeout=_FILE_TIMEOUT, connect_timeout=_FILE_TIMEOUT)
         logger.info("image_to_url: downloaded in %.1fs", time() - t0)
         if extension != "jpg":
             file.seek(0)

--- a/reverse_image_search_bot/engines/errors.py
+++ b/reverse_image_search_bot/engines/errors.py
@@ -4,7 +4,24 @@ Engines raise these to signal error conditions. The dispatch code in
 commands.py catches them and decides what (if anything) to show the user.
 """
 
-__all__ = ["EngineError", "RateLimitError", "SearchError"]
+import httpx
+
+__all__ = ["EngineError", "RateLimitError", "SearchError", "is_transient"]
+
+#: Exception types that indicate a transient network problem — not a bug.
+#: Deliberately no bare OSError — that would swallow real bugs (ffmpeg, file I/O).
+_TRANSIENT_TYPES = (httpx.TimeoutException, httpx.TransportError, ConnectionError, TimeoutError)
+
+
+def is_transient(exc: BaseException | None) -> bool:
+    """Walk the exception chain looking for transient network errors (timeouts, DNS, connect failures)."""
+    seen: set[int] = set()
+    while exc is not None and id(exc) not in seen:
+        seen.add(id(exc))
+        if isinstance(exc, _TRANSIENT_TYPES):
+            return True
+        exc = exc.__cause__ or exc.__context__
+    return False
 
 
 class EngineError(Exception):
@@ -27,4 +44,14 @@ class RateLimitError(EngineError):
 
 
 class SearchError(EngineError):
-    """Search failed (network, parsing, bad response, etc.)."""
+    """Search failed (network, parsing, bad response, etc.).
+
+    Args:
+        message: Internal log message.
+        report: When False, the error is logged locally but not sent to
+            error tracking (use for known-broken upstreams we can't fix).
+    """
+
+    def __init__(self, message: str = "Search failed", *, report: bool = True):
+        super().__init__(message)
+        self.report = report

--- a/reverse_image_search_bot/engines/pic_image_search.py
+++ b/reverse_image_search_bot/engines/pic_image_search.py
@@ -27,6 +27,11 @@ class PicImageSearchEngine(GenericRISEngine):
 
     pic_engine_class = None  # e.g. PicImageSearch.Yandex
 
+    #: Hardcoded kill-switch for ParsingError reporting to error tracking.
+    #: Set False on a subclass when the upstream parser is known-broken
+    #: (e.g. site markup changed) and flip back once PicImageSearch ships a fix.
+    report_parsing_errors = True
+
     @_classproperty
     def best_match_implemented(cls):
         return True
@@ -74,9 +79,13 @@ class PicImageSearchEngine(GenericRISEngine):
         except Exception as e:
             from PicImageSearch.exceptions import ParsingError
 
+            from .errors import is_transient
+
             if isinstance(e, ParsingError):
-                raise SearchError(f"ParsingError: {e}") from e
-            raise SearchError(f"Search failed: {e}") from e
+                raise SearchError(f"ParsingError: {e}", report=self.report_parsing_errors) from e
+            # str() of httpx timeouts is often empty — keep the type name.
+            detail = str(e) or type(e).__name__
+            raise SearchError(f"Search failed: {detail}", report=not is_transient(e)) from e
 
         if not getattr(result_obj, "raw", None):
             self.logger.debug("Done: no results")

--- a/reverse_image_search_bot/engines/yandex.py
+++ b/reverse_image_search_bot/engines/yandex.py
@@ -13,6 +13,11 @@ class YandexEngine(PicImageSearchEngine):
     recommendation = ["Anything SFW and NSFW", "Image to Text (OCR)", "Anything Russian"]
     url = "https://yandex.com/images/search?url={query_url}&rpt=imageview"
 
+    # PicImageSearch's Yandex parser is broken upstream ('data-state' extraction
+    # fails since Yandex changed their markup). Flip back to True once we update
+    # to a PicImageSearch release that fixes it.
+    report_parsing_errors = False
+
     def __init__(self, *args, **kwargs):
         from PicImageSearch import Yandex
 

--- a/tests/test_engine_error_reporting.py
+++ b/tests/test_engine_error_reporting.py
@@ -1,0 +1,35 @@
+"""Tests for error-tracking noise triage (transient detection, report flags)."""
+
+import httpx
+import pytest
+
+from reverse_image_search_bot.engines.errors import SearchError, is_transient
+
+
+def test_chained_timeout_is_transient():
+    with pytest.raises(SearchError) as exc_info:
+        try:
+            raise httpx.ConnectTimeout("")
+        except Exception as e:
+            raise SearchError("Search failed: ConnectTimeout") from e
+    assert is_transient(exc_info.value)
+
+
+def test_http_5xx_is_not_transient():
+    assert not is_transient(SearchError("SauceNAO returned HTTP 500"))
+
+
+def test_oserror_is_not_transient():
+    # ffmpeg / file I/O errors are real bugs, must stay reported
+    assert not is_transient(OSError("ffmpeg boom"))
+
+
+def test_search_error_report_flag():
+    assert SearchError("x").report is True
+    assert SearchError("x", report=False).report is False
+
+
+def test_yandex_parsing_reporting_disabled():
+    from reverse_image_search_bot.engines.yandex import YandexEngine
+
+    assert YandexEngine.report_parsing_errors is False


### PR DESCRIPTION
Fixes the top noise sources from Bugsink (project `reverse-image-search`, ~5k events):

- **~4700x `SearchError: Search failed: `** — httpx timeouts chained into SearchError and shipped to error tracking. New `is_transient()` walks the exception chain; transient network errors log at `info` instead. Empty `str(e)` now falls back to the exception type name.
- **178x `TimedOut` on getFile** — PTB's 5s default read timeout too tight for media; bumped to 10s for `get_file`/downloads.
- **84x Yandex `ParsingError`** — PicImageSearch's Yandex parser is broken upstream (no fix released yet). Added `report_parsing_errors` class toggle on `PicImageSearchEngine`, hardcoded off for Yandex; flip back on once we update to a fixed PicImageSearch.
- **14x + 9x `BadRequest: Message to edit/be replied not found`** — user deletes their message mid-search. `Defaults(allow_sending_without_reply=True)` covers all replies; `suppress(BadRequest)` on the searching-message edits.

Deliberately untouched: SauceNAO 5xx (kept reported — may be raised with SauceNAO upstream).

Tests: 437 passed, ruff clean. New `tests/test_engine_error_reporting.py` covers transient detection + report flags.