### PR TITLE
Don't report AnimeTrace JSONDecodeError noise from empty provider bodies

### DIFF
--- a/reverse_image_search_bot/engines/pic_image_search.py
+++ b/reverse_image_search_bot/engines/pic_image_search.py
@@ -77,12 +77,18 @@ class PicImageSearchEngine(GenericRISEngine):
         except KeyError as e:
             raise SearchError(f"Parsing key missing: {e}") from e
         except Exception as e:
+            import json
+
             from PicImageSearch.exceptions import ParsingError
 
             from .errors import is_transient
 
             if isinstance(e, ParsingError):
                 raise SearchError(f"ParsingError: {e}", report=self.report_parsing_errors) from e
+            if isinstance(e, json.JSONDecodeError):
+                # Provider returned an empty / non-JSON body (rate-limit page, 5xx
+                # HTML, truncated response) — an upstream hiccup, not our bug.
+                raise SearchError(f"Bad response body: {e}", report=False) from e
             # str() of httpx timeouts is often empty — keep the type name.
             detail = str(e) or type(e).__name__
             raise SearchError(f"Search failed: {detail}", report=not is_transient(e)) from e

--- a/tests/test_engine_error_reporting.py
+++ b/tests/test_engine_error_reporting.py
@@ -33,3 +33,24 @@ def test_yandex_parsing_reporting_disabled():
     from reverse_image_search_bot.engines.yandex import YandexEngine
 
     assert YandexEngine.report_parsing_errors is False
+
+
+@pytest.mark.asyncio
+async def test_json_decode_from_provider_is_not_reported(monkeypatch):
+    """An empty/non-JSON provider body (JSONDecodeError) must be caught as a
+    non-reported SearchError, not shipped to error tracking as a bug."""
+    import json
+
+    from reverse_image_search_bot.engines.yandex import YandexEngine
+
+    engine = YandexEngine()
+
+    async def _boom(_url):
+        json.loads("")  # raises JSONDecodeError
+
+    monkeypatch.setattr(engine, "_search", _boom)
+
+    with pytest.raises(SearchError) as exc_info:
+        await engine.best_match("https://example.com/x.jpg")
+    assert exc_info.value.report is False
+    assert isinstance(exc_info.value.__cause__, json.JSONDecodeError)


### PR DESCRIPTION
Follow-up to #148. New Bugsink flood: `SearchError: Search failed: Expecting value: line 1 column 1 (char 0)` from AnimeTrace.

**Cause:** AnimeTrace's API intermittently returns an empty/non-JSON body; PicImageSearch does `json_loads(resp.text)` → stdlib `json.JSONDecodeError`. It's not a `ParsingError` and not an httpx timeout, so `is_transient()` tagged it reportable.

**Fix:** catch `JSONDecodeError` in `PicImageSearchEngine.best_match` → `SearchError(report=False)`. An unparseable provider body is an upstream availability hiccup, not our bug — same bucket as Yandex `ParsingError`. Applies to all PicImageSearch engines (AnimeTrace, Yandex), not a one-off.

Test added asserting the JSON-decode path is non-reported. 438 pass, ruff + ty clean.