### PR TITLE
Don't AssertionError on edited feedback replies

### DIFF
--- a/reverse_image_search_bot/commands/feedback.py
+++ b/reverse_image_search_bot/commands/feedback.py
@@ -116,7 +116,10 @@ async def _send_to_user_or_chat(
 
 async def feedback_reply_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle replies to feedback messages — forwards between admin and user."""
-    assert update.message and update.effective_chat and update.message.reply_to_message
+    # The REPLY filter also matches edited messages, where update.message is None
+    # (the payload is update.edited_message). Ignore those rather than asserting.
+    if not (update.message and update.effective_chat and update.message.reply_to_message):
+        return
 
     reply_to = update.message.reply_to_message
     chat_id = update.effective_chat.id

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -955,3 +955,19 @@ class TestFileHandler:
             # Should have sent error message before re-raising
             update.effective_message.reply_text.assert_awaited()
             assert "error" in update.effective_message.reply_text.call_args[0][0].lower()
+
+
+@pytest.mark.asyncio
+async def test_feedback_reply_handler_ignores_edited_message():
+    """An edited reply matches the REPLY filter but carries update.message=None
+    (the payload is update.edited_message). The handler must return quietly,
+    not raise AssertionError (which floods error tracking)."""
+    from reverse_image_search_bot.commands.feedback import feedback_reply_handler
+
+    update = MagicMock()
+    update.message = None  # edited-message update
+    update.effective_chat = MagicMock(id=123)
+    context = MagicMock()
+
+    # Previously raised AssertionError → must now be a no-op.
+    await feedback_reply_handler(update, context)


### PR DESCRIPTION
Follow-up noise fix. Bugsink: `AssertionError` at `feedback.py:119`.

**Cause:** `feedback_reply_handler` is registered with `filters.REPLY & filters.TEXT & filters.ChatType.PRIVATE`. MessageHandler filters run against `effective_message`, so the handler also fires on **edited** messages — where the update payload is `edited_message` and `update.message is None`. The `assert update.message and …` then throws `AssertionError` into the handler and it's logged/reported.

**Fix:** an `assert` is the wrong tool for validating untrusted update shape. Replaced with a guard-return — an edited reply is simply ignored (we don't want to re-forward edits anyway).

Test added (proven falsifiable: fails with the old assert, passes with the guard). 438 pass, ruff + ty clean.