### PR TITLE
Report pipeline: channel-forward provenance fix, prepare status, 25-image cap + Show more, cleared-file state

### DIFF
--- a/reverse_image_search_bot/abuse_report/prepare.py
+++ b/reverse_image_search_bot/abuse_report/prepare.py
@@ -21,6 +21,10 @@ from reverse_image_search_bot.config import abuse
 
 logger = logging.getLogger("abuse.prepare")
 
+# Hard cap on files encrypted into a report round at once. Reports with more
+# on-disk uploads get a "show more" in the webview that prepares the next batch.
+PREPARE_BATCH = 25
+
 
 def upload_dir() -> Path | None:
     p = settings.UPLOADER.get("configuration", {}).get("path")
@@ -54,6 +58,7 @@ class PrepareResult:
         report_uuid: str | None = None,
         p1: str | None = None,
         encrypted: int = 0,
+        remaining: int = 0,
         error: str | None = None,
         existing_uuid: str | None = None,
         filed_uuid: str | None = None,
@@ -62,6 +67,9 @@ class PrepareResult:
         self.report_uuid = report_uuid
         self.p1 = p1
         self.encrypted = encrypted
+        # Files still on disk but beyond the PREPARE_BATCH cap — preparable via
+        # the webview's "show more".
+        self.remaining = remaining
         self.error = error
         self.existing_uuid = existing_uuid
         # Set when the failure is "already filed with NCMEC" so the caller can
@@ -74,60 +82,34 @@ class PrepareResult:
         return self.report_uuid is not None
 
 
-def prepare_report(user_id: int) -> PrepareResult:
-    """Gather → encrypt → create a ``ready`` report for ``user_id``.
+def _present_files(user_id: int) -> tuple[list, int, int]:
+    """Files still on disk for a user, excluding cleared ones.
 
-    Returns a :class:`PrepareResult`. On success it carries the new
-    ``report_uuid``, the one-time image key ``p1`` (shown once, never stored),
-    and the ``encrypted`` file count.
+    Returns ``(present, recorded, cleared)`` where ``present`` is a list of
+    ``(file_row, path)``, ``recorded`` the total recorded file count, and
+    ``cleared`` how many on-disk files were skipped as cleared.
     """
-    if not settings.REPORT_BASE_URL:
-        return PrepareResult(error="Report server is not configured (REPORT_BASE_URL unset).")
-
-    existing = abuse.active_report_for_user(user_id)
-    if existing:
-        return PrepareResult(
-            error=f"An active report already exists for user {user_id} (status: {existing['status']}).",
-            existing_uuid=existing["report_uuid"],
-        )
-
     files = abuse.files_for_user(user_id)
     updir = upload_dir()
     present = []
+    cleared = 0
     for f in files:
-        if updir:
-            fp = updir / f["saved_filename"]
-            if fp.is_file():
-                present.append((f, fp))
-    if not present:
-        filed = abuse.latest_filed_report_for_user(user_id)
-        if filed and filed.get("ncmec_report_id"):
-            n = filed.get("reported_files", 0)
-            others = f" along with {n - 1} other file(s)" if n and n > 1 else ""
-            return PrepareResult(
-                error=(
-                    f"User {user_id} was already filed with NCMEC in report "
-                    f"#{filed['ncmec_report_id']}{others}. The plaintext files were "
-                    f"deleted from disk after filing (the encrypted copies are kept "
-                    f"in that report) — nothing new to report."
-                ),
-                filed_uuid=filed["report_uuid"],
-                filed_ncmec_id=filed["ncmec_report_id"],
-            )
-        return PrepareResult(
-            error=f"User {user_id} has {len(files)} recorded file(s) but none are still on disk — nothing to report."
-        )
+        if not updir:
+            continue
+        fp = updir / f["saved_filename"]
+        if not fp.is_file():
+            continue
+        if f.get("cleared_at"):
+            cleared += 1
+            continue
+        present.append((f, fp))
+    return present, len(files), cleared
 
-    # P1 is the one-time image key — shown ONCE and never stored. The page
-    # password is a single global secret (REPORT_PAGE_PASSWORD), not per-report.
-    p1 = crypto.gen_password()
-    report_uuid = crypto.gen_report_uuid()
-    key = crypto.derive_key(p1)
 
-    abuse.create_report(report_uuid, user_id, "")
-
+def _encrypt_batch(report_uuid: str, batch: list, key: bytes) -> int:
+    """Encrypt a batch of (file_row, path) into report blobs. Returns count."""
     encrypted = 0
-    for f, fp in present:
+    for f, fp in batch:
         try:
             data = fp.read_bytes()
         except Exception:
@@ -143,6 +125,98 @@ def prepare_report(user_id: int) -> PrepareResult:
             plaintext_sha256=crypto.sha256_hex(data),
         )
         encrypted += 1
+    return encrypted
 
+
+def prepare_report(user_id: int) -> PrepareResult:
+    """Gather → encrypt → create a ``ready`` report for ``user_id``.
+
+    Returns a :class:`PrepareResult`. On success it carries the new
+    ``report_uuid``, the one-time image key ``p1`` (shown once, never stored),
+    and the ``encrypted`` file count. At most ``PREPARE_BATCH`` files are
+    encrypted; the rest are reported via ``remaining`` (the webview's
+    "show more" prepares them in later batches).
+    """
+    if not settings.REPORT_BASE_URL:
+        return PrepareResult(error="Report server is not configured (REPORT_BASE_URL unset).")
+
+    existing = abuse.active_report_for_user(user_id)
+    if existing:
+        return PrepareResult(
+            error=f"An active report already exists for user {user_id} (status: {existing['status']}).",
+            existing_uuid=existing["report_uuid"],
+        )
+
+    present, recorded, cleared = _present_files(user_id)
+    if not present:
+        if cleared:
+            return PrepareResult(
+                error=f"All {cleared} remaining file(s) of user {user_id} are marked cleared — nothing to report."
+            )
+        filed = abuse.latest_filed_report_for_user(user_id)
+        if filed and filed.get("ncmec_report_id"):
+            n = filed.get("reported_files", 0)
+            others = f" along with {n - 1} other file(s)" if n and n > 1 else ""
+            return PrepareResult(
+                error=(
+                    f"User {user_id} was already filed with NCMEC in report "
+                    f"#{filed['ncmec_report_id']}{others}. The plaintext files were "
+                    f"deleted from disk after filing (the encrypted copies are kept "
+                    f"in that report) — nothing new to report."
+                ),
+                filed_uuid=filed["report_uuid"],
+                filed_ncmec_id=filed["ncmec_report_id"],
+            )
+        return PrepareResult(
+            error=f"User {user_id} has {recorded} recorded file(s) but none are still on disk — nothing to report."
+        )
+
+    # P1 is the one-time image key — shown ONCE and never stored. The page
+    # password is a single global secret (REPORT_PAGE_PASSWORD), not per-report.
+    p1 = crypto.gen_password()
+    report_uuid = crypto.gen_report_uuid()
+    key = crypto.derive_key(p1)
+
+    abuse.create_report(report_uuid, user_id, "")
+    batch = present[:PREPARE_BATCH]
+    encrypted = _encrypt_batch(report_uuid, batch, key)
     abuse.set_report_status(report_uuid, abuse.REPORT_READY)
-    return PrepareResult(report_uuid=report_uuid, p1=p1, encrypted=encrypted)
+    return PrepareResult(report_uuid=report_uuid, p1=p1, encrypted=encrypted, remaining=len(present) - len(batch))
+
+
+def pending_files(report_uuid: str) -> int:
+    """How many of the report user's on-disk, non-cleared files are NOT yet blobs."""
+    rep = abuse.get_report(report_uuid)
+    if not rep:
+        return 0
+    in_report = {b["file_unique_id"] for b in abuse.report_blobs(report_uuid)}
+    present, _, _ = _present_files(rep["user_id"])
+    return sum(1 for f, _ in present if f["file_unique_id"] not in in_report)
+
+
+def extend_report(report_uuid: str, p1: str) -> PrepareResult:
+    """Encrypt the next ``PREPARE_BATCH`` not-yet-included files into the report.
+
+    ``p1`` must be the report's original image key — it is verified against an
+    existing blob's hash before anything is encrypted, so a typo can't split the
+    report across two keys.
+    """
+    rep = abuse.get_report(report_uuid)
+    if not rep:
+        return PrepareResult(error="report not found")
+    key = crypto.derive_key(p1)
+    blobs = abuse.report_blobs(report_uuid)
+    if blobs:
+        probe = blobs[0]
+        try:
+            data = crypto.decrypt_file(bytes(probe["nonce"]), bytes(probe["ciphertext"]), key)
+        except Exception:
+            return PrepareResult(error="image key (P1) incorrect")
+        if crypto.sha256_hex(data) != probe["plaintext_sha256"]:
+            return PrepareResult(error="image key (P1) incorrect")
+    in_report = {b["file_unique_id"] for b in blobs}
+    present, _, _ = _present_files(rep["user_id"])
+    todo = [(f, fp) for f, fp in present if f["file_unique_id"] not in in_report]
+    batch = todo[:PREPARE_BATCH]
+    encrypted = _encrypt_batch(report_uuid, batch, key)
+    return PrepareResult(report_uuid=report_uuid, encrypted=encrypted, remaining=len(todo) - len(batch))

--- a/reverse_image_search_bot/abuse_report/server.py
+++ b/reverse_image_search_bot/abuse_report/server.py
@@ -18,6 +18,8 @@ to hand to NCMEC.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import hashlib
 import hmac
 import json
@@ -31,7 +33,7 @@ from aiohttp import web
 from reverse_image_search_bot import settings
 from reverse_image_search_bot.abuse_report import crypto, ncmec
 from reverse_image_search_bot.abuse_report import video as abuse_video
-from reverse_image_search_bot.abuse_report.prepare import prepare_report, resolve_user
+from reverse_image_search_bot.abuse_report.prepare import extend_report, pending_files, prepare_report, resolve_user
 from reverse_image_search_bot.config import abuse
 
 logger = logging.getLogger("abuse.server")
@@ -174,7 +176,9 @@ async def api_reports_create(request: web.Request) -> web.Response:
     if user_id is None:
         raise web.HTTPNotFound(text=f"no uploader found for: {target}")
 
-    result = prepare_report(user_id)
+    # prepare_report encrypts up to a batch of files (PBKDF2 + AES) — run it off
+    # the event loop so a big report can't stall the webhook/report server.
+    result = await asyncio.to_thread(prepare_report, user_id)
     if not result.ok:
         # An existing active report is a 409 carrying its uuid so the UI can jump to it.
         if result.existing_uuid:
@@ -194,6 +198,7 @@ async def api_reports_create(request: web.Request) -> web.Response:
             "user_id": user_id,
             "p1": result.p1,
             "encrypted": result.encrypted,
+            "remaining": result.remaining,
         }
     )
 
@@ -251,6 +256,35 @@ async def api_unlock(request: web.Request) -> web.Response:
                 "language_code": user.get("language_code"),
                 "banned_at": user.get("banned_at"),
             },
+            "blobs": abuse.blob_meta(rep["report_uuid"]),
+            # On-disk, non-cleared files of this user NOT yet in the report —
+            # drives the gallery's "show more" button.
+            "pending": pending_files(rep["report_uuid"]),
+        }
+    )
+
+
+async def api_extend(request: web.Request) -> web.Response:
+    """Prepare the next batch of the user's files into this report ("show more").
+
+    Requires the report's image key (P1) so the new blobs share the existing
+    encryption key. Returns the refreshed blob list + how many are still pending.
+    """
+    _require_admin(request)
+    rep = _report_or_404(request.match_info["uuid"])
+    _require_page_secret(request, rep)
+    payload = await request.json()
+    p1 = payload.get("image_key", "")
+    if not p1:
+        raise web.HTTPBadRequest(text="image_key (P1) required")
+    result = await asyncio.to_thread(extend_report, rep["report_uuid"], p1)
+    if not result.ok:
+        raise web.HTTPBadRequest(text=result.error or "could not extend report")
+    return web.json_response(
+        {
+            "ok": True,
+            "encrypted": result.encrypted,
+            "remaining": result.remaining,
             "blobs": abuse.blob_meta(rep["report_uuid"]),
         }
     )
@@ -571,6 +605,10 @@ async def api_submit(request: web.Request) -> web.Response:
 
     abuse.set_report_ncmec_id(rep["report_uuid"], report_id)
     abuse.mark_report_filed(rep["report_uuid"])
+    # Filing IS the decision: every file in the round the admin did NOT select is
+    # thereby cleared (not problematic) and excluded from future reports.
+    unselected = [b["file_unique_id"] for b in abuse.report_blobs(rep["report_uuid"]) if not b["selected"]]
+    abuse.set_files_cleared(unselected)
     _cleanup_after_finish(rep)
     _ban_reported_user(request.app.get("bot_data"), rep["user_id"])
     return web.json_response({"ok": True, "ncmec_report_id": report_id, "status": abuse.REPORT_FILED})
@@ -582,10 +620,19 @@ async def api_cancel(request: web.Request) -> web.Response:
     Cancelling means the user did nothing wrong, so we KEEP the user's original
     files on disk and the filename->user (files table) relation untouched. Only
     the report's encrypted blobs + the report row's status are affected.
+
+    Optional ``clear_files`` in the JSON body additionally marks every file in
+    the round as cleared (not problematic) — excluded from future reports.
     """
     _require_admin(request)
     rep = _report_or_404(request.match_info["uuid"])
     _require_page_secret(request, rep)
+    clear_files = False
+    with contextlib.suppress(Exception):
+        # `is True` (not truthiness) so a missing/odd body can never clear files.
+        clear_files = (await request.json()).get("clear_files") is True
+    if clear_files:
+        abuse.set_files_cleared([b["file_unique_id"] for b in abuse.report_blobs(rep["report_uuid"])])
     abuse.set_report_status(rep["report_uuid"], abuse.REPORT_CANCELLED)
     # Delete any encrypted video ciphertext on disk, then purge blobs (DB only —
     # NOT the files table, NOT the user's original disk files).
@@ -691,6 +738,7 @@ def build_app(bot=None, bot_data=None) -> web.Application:
     app.router.add_get("/report/{uuid}/api/blob/{blob_id}/video", api_video)
     app.router.add_get("/report/{uuid}/api/status", api_status)
     app.router.add_post("/report/{uuid}/api/select", api_select)
+    app.router.add_post("/report/{uuid}/api/extend", api_extend)
     app.router.add_post("/report/{uuid}/api/review", api_review)
     app.router.add_post("/report/{uuid}/api/submit", api_submit)
     app.router.add_post("/report/{uuid}/api/cancel", api_cancel)

--- a/reverse_image_search_bot/abuse_report/static/report.html
+++ b/reverse_image_search_bot/abuse_report/static/report.html
@@ -166,6 +166,10 @@
         <span class="muted"><span id="save-state" style="color:#7fd6a2;margin-right:8px"></span><span id="sel-count">0 selected</span></span>
       </div>
       <div class="gallery" id="gallery"></div>
+      <div class="row" style="margin-top:10px">
+        <button id="more-btn" class="secondary hidden">Show more</button>
+      </div>
+      <div class="muted" id="more-err" style="color:#f08a8a;margin-top:6px"></div>
     </div>
 
     <div class="card" id="action-card">
@@ -196,6 +200,22 @@
     <h2 id="notice-title"></h2>
     <div class="muted" id="notice-body" style="margin-bottom:14px"></div>
     <div class="row"><button id="notice-ok-btn">OK</button></div>
+  </div>
+</dialog>
+
+<!-- Cancel confirmation -->
+<dialog id="cancel-dlg">
+  <div class="dlg-body">
+    <h2>Cancel this report?</h2>
+    <div class="muted" style="margin-bottom:12px">The encrypted blobs and this report are discarded, but the user's original files and records are KEPT.</div>
+    <label style="display:flex;gap:8px;align-items:flex-start;font-size:14px;color:#e8e8ea;margin-bottom:14px;cursor:pointer">
+      <input type="checkbox" id="cancel-clear" style="margin-top:3px">
+      <span>Mark all images in this round as <b>cleared</b> (not problematic) — they will be excluded from future reports.</span>
+    </label>
+    <div class="row">
+      <button id="cancel-confirm-btn" class="danger">Cancel report</button>
+      <button id="cancel-back-btn" class="ghost">Back</button>
+    </div>
   </div>
 </dialog>
 
@@ -326,6 +346,7 @@ function renderGallery() {
     g.appendChild(d);
   }
   updateSelCount();
+  updateMoreBtn();
 }
 
 $("decrypt-btn").onclick = async () => {
@@ -410,6 +431,45 @@ function wireCls(id) {
 function updateSelCount() {
   $("sel-count").textContent = Object.keys(sel).length + " selected";
 }
+
+// --- "Show more": prepare the next batch of pending files into this report ---
+function updateMoreBtn() {
+  const btn = $("more-btn");
+  const pending = META.pending || 0;
+  const active = !["filed", "cancelled"].includes(META.status);
+  btn.classList.toggle("hidden", !(pending > 0 && active));
+  if (pending > 0) btn.textContent = `Show more (${pending} pending)`;
+}
+
+$("more-btn").onclick = async () => {
+  $("more-err").textContent = "";
+  if (!P1KEY) { $("more-err").textContent = "Decrypt the images first — the image key is needed to add more."; return; }
+  const btn = $("more-btn"); btn.disabled = true; btn.textContent = "Preparing…";
+  try {
+    const r = await api("/api/extend", {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ image_key: $("p1").value }),
+    });
+    const j = await r.json();
+    const known = new Set(META.blobs.map(b => b.id));
+    const added = j.blobs.filter(b => !known.has(b.id));
+    META.blobs = j.blobs;
+    META.pending = j.remaining;
+    const g = $("gallery");
+    for (const b of added) {
+      const d = document.createElement("div");
+      d.className = "thumb"; d.dataset.id = b.id;
+      d.innerHTML = `<div class="fname">${blobLabel(b)}</div><div class="lock">🔒</div>`;
+      g.appendChild(d);
+      await decryptThumb(b);
+    }
+  } catch (e) {
+    $("more-err").textContent = "" + e.message;
+  } finally {
+    btn.disabled = false;
+    updateMoreBtn();
+  }
+};
 
 // --- viewer dialog (image + optional source video) ---------------------------
 const viewer = $("viewer");
@@ -733,14 +793,23 @@ function showSuccess(reportId) {
 }
 
 // --- Cancel (nothing filed) --------------------------------------------------
-$("cancel-btn").onclick = async () => {
-  if (!confirm("Cancel this report? The encrypted blobs and this report are discarded, but the user's original files and records are KEPT.")) return;
+const cancelDlg = $("cancel-dlg");
+$("cancel-btn").onclick = () => { $("cancel-clear").checked = false; cancelDlg.showModal(); };
+$("cancel-back-btn").onclick = () => cancelDlg.close();
+$("cancel-confirm-btn").onclick = async () => {
+  const clearFiles = $("cancel-clear").checked;
   try {
-    await api("/api/cancel", { method: "POST" });
+    await api("/api/cancel", {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ clear_files: clearFiles }),
+    });
+    cancelDlg.close();
     applyFinalState("cancelled");
     window.scrollTo({ top: 0, behavior: "smooth" });
-    showNotice("Report cancelled", "The report was cancelled. The encrypted blobs were discarded; the user's original files and records are kept.");
-  } catch (e) { $("action-err").textContent = "" + e.message; }
+    showNotice("Report cancelled",
+      "The report was cancelled. The encrypted blobs were discarded; the user's original files and records are kept."
+      + (clearFiles ? " All images in this round were marked cleared (not problematic)." : ""));
+  } catch (e) { cancelDlg.close(); $("action-err").textContent = "" + e.message; }
 };
 
 // --- generic notice dialog (OK to dismiss) -----------------------------------
@@ -764,6 +833,7 @@ function applyFinalState(status, reportId) {
   // Keep the decrypt card + gallery available after filing so the reported
   // images can still be inspected; only the submit/cancel actions are removed.
   $("action-card").classList.add("hidden");
+  updateMoreBtn();
   if (status === "filed") {
     applyFiledLayout();
     window.scrollTo({ top: 0, behavior: "smooth" });

--- a/reverse_image_search_bot/abuse_report/static/report.html
+++ b/reverse_image_search_bot/abuse_report/static/report.html
@@ -210,7 +210,7 @@
     <div class="muted" style="margin-bottom:12px">The encrypted blobs and this report are discarded, but the user's original files and records are KEPT.</div>
     <label style="display:flex;gap:8px;align-items:flex-start;font-size:14px;color:#e8e8ea;margin-bottom:14px;cursor:pointer">
       <input type="checkbox" id="cancel-clear" style="margin-top:3px">
-      <span>Mark all images in this round as <b>cleared</b> (not problematic) — they will be excluded from future reports.</span>
+      <span>Mark all images in this round as <b>cleared</b>.</span>
     </label>
     <div class="row">
       <button id="cancel-confirm-btn" class="danger">Cancel report</button>
@@ -443,7 +443,7 @@ function updateMoreBtn() {
 
 $("more-btn").onclick = async () => {
   $("more-err").textContent = "";
-  if (!P1KEY) { $("more-err").textContent = "Decrypt the images first — the image key is needed to add more."; return; }
+  if (!P1KEY) { $("more-err").textContent = "Image key is needed to load more."; return; }
   const btn = $("more-btn"); btn.disabled = true; btn.textContent = "Preparing…";
   try {
     const r = await api("/api/extend", {
@@ -808,7 +808,7 @@ $("cancel-confirm-btn").onclick = async () => {
     window.scrollTo({ top: 0, behavior: "smooth" });
     showNotice("Report cancelled",
       "The report was cancelled. The encrypted blobs were discarded; the user's original files and records are kept."
-      + (clearFiles ? " All images in this round were marked cleared (not problematic)." : ""));
+      + (clearFiles ? " All images in this round were marked cleared." : ""));
   } catch (e) { cancelDlg.close(); $("action-err").textContent = "" + e.message; }
 };
 

--- a/reverse_image_search_bot/commands/report.py
+++ b/reverse_image_search_bot/commands/report.py
@@ -12,6 +12,7 @@ work on one) plus a form to create a new report from a username or filename.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import html
 import logging
@@ -97,18 +98,29 @@ async def report_users(
     expansion) both resolve target user ids their own way, then hand them here so
     the outcome list looks identical everywhere.
     """
+    if not update.message:
+        return
     rows: list[dict] = []  # {icon, user_id, username, detail, uuid?}
-    for uid in dict.fromkeys(user_ids):  # de-dup, preserve order
+    uids = list(dict.fromkeys(user_ids))  # de-dup, preserve order
+    # Encrypting a round takes a while (PBKDF2 + AES per file) — tell the admin
+    # right away, and run the work off the event loop so nothing times out.
+    status_msg = None
+    with contextlib.suppress(Exception):
+        status_msg = await update.message.reply_text(
+            f"⏳ Preparing report{'s' if len(uids) != 1 else ''} for {len(uids)} user(s)…"
+        )
+    for uid in uids:
         user = abuse.get_user(uid) or {}
         uname = f"@{user['username']}" if user.get("username") else "—"
-        result = prepare_report(uid)
+        result = await asyncio.to_thread(prepare_report, uid)
         if result.ok:
+            more = f" (+{result.remaining} more via Show more)" if result.remaining else ""
             rows.append(
                 {
                     "icon": "🆕",
                     "user_id": uid,
                     "username": uname,
-                    "detail": f"P1 <code>{html.escape(result.p1 or '')}</code>",
+                    "detail": f"P1 <code>{html.escape(result.p1 or '')}</code>{more}",
                     "uuid": result.report_uuid,
                 }
             )
@@ -135,6 +147,9 @@ async def report_users(
         else:
             rows.append({"icon": "⏭", "user_id": uid, "username": uname, "detail": "nothing to report", "uuid": None})
 
+    if status_msg is not None:
+        with contextlib.suppress(Exception):
+            await status_msg.delete()
     await _send_report_summary(update, context, rows, unknown or [])
 
 
@@ -218,7 +233,13 @@ async def start_report(update: Update, context: ContextTypes.DEFAULT_TYPE, user_
     """
     assert update.message and update.effective_user
 
-    result = prepare_report(user_id)
+    status_msg = None
+    with contextlib.suppress(Exception):
+        status_msg = await update.message.reply_text("⏳ Preparing report…")
+    result = await asyncio.to_thread(prepare_report, user_id)
+    if status_msg is not None:
+        with contextlib.suppress(Exception):
+            await status_msg.delete()
     if not result.ok:
         msg = result.error or "Could not prepare a report."
         if result.existing_uuid and settings.REPORT_BASE_URL:
@@ -248,8 +269,13 @@ async def start_report(update: Update, context: ContextTypes.DEFAULT_TYPE, user_
     )
     await update.message.reply_html(
         f"<b>Report prepared</b> for user <code>{user_id}</code> ({html.escape(uname)})\n"
-        f"Encrypted <b>{result.encrypted}</b> file(s).\n\n"
-        f"<b>Image key (P1):</b> <code>{html.escape(result.p1 or '')}</code>\n\n"
+        f"Encrypted <b>{result.encrypted}</b> file(s)."
+        + (
+            f" <b>{result.remaining}</b> more can be added via the page's Show more button.\n\n"
+            if result.remaining
+            else "\n\n"
+        )
+        + f"<b>Image key (P1):</b> <code>{html.escape(result.p1 or '')}</code>\n\n"
         f"{launch}\n\n"
         f"<i>Use the global page password to open the report, then P1 to decrypt "
         f"the images. P1 is not stored — if you lose it the thumbnails can't be "

--- a/reverse_image_search_bot/commands/search.py
+++ b/reverse_image_search_bot/commands/search.py
@@ -148,6 +148,18 @@ async def file_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, messa
                 elif sender_chat.type in ("group", "supergroup"):
                     group_id = sender_chat.id
                     abuse.record_chat(sender_chat.id, "group", title=sender_chat.title, username=sender_chat.username)
+            # A FORWARDED post carries its source chat in forward_origin (e.g. a
+            # channel post forwarded into the bot DM) — that chat is provenance
+            # too, otherwise reporting the channel finds no uploads.
+            origin = getattr(message, "forward_origin", None)
+            origin_chat = getattr(origin, "chat", None) or getattr(origin, "sender_chat", None)
+            if origin_chat is not None:
+                if origin_chat.type == "channel":
+                    channel_id = origin_chat.id
+                    abuse.record_chat(origin_chat.id, "channel", title=origin_chat.title, username=origin_chat.username)
+                elif origin_chat.type in ("group", "supergroup"):
+                    group_id = origin_chat.id
+                    abuse.record_chat(origin_chat.id, "group", title=origin_chat.title, username=origin_chat.username)
             abuse.record_user(
                 user.id,
                 username=user.username,

--- a/reverse_image_search_bot/config/abuse.py
+++ b/reverse_image_search_bot/config/abuse.py
@@ -148,6 +148,11 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     _add_column_if_missing(conn, "files", "is_video", "INTEGER NOT NULL DEFAULT 0")
     conn.execute("UPDATE files SET is_video = 1 WHERE file_type IN ('video', 'gif')")
 
+    # A file the admin marked as NOT problematic ("cleared") — excluded from
+    # report preparation just like already-filed pieces. Set from the cancel
+    # dialog, or automatically for unselected files when a report is filed.
+    _add_column_if_missing(conn, "files", "cleared_at", "INTEGER")
+
     # A report round for one user. `report_uuid` is the URL token; `page_secret_hash`
     # gates the report page (P2, stored hashed — the image key P1 is NEVER stored).
     # `status` drives the live UI: preparing -> ready -> submitting -> filed / retracted
@@ -410,6 +415,23 @@ def files_for_user(user_id: int) -> list[dict]:
     conn = _get_conn()
     rows = conn.execute("SELECT * FROM files WHERE user_id = ? ORDER BY upload_time", (user_id,)).fetchall()
     return [dict(r) for r in rows]
+
+
+def set_files_cleared(file_unique_ids: list[str]) -> int:
+    """Mark files as cleared (not problematic). Returns count updated.
+
+    Cleared files are excluded from report preparation, like filed pieces.
+    """
+    if not file_unique_ids:
+        return 0
+    conn = _get_conn()
+    placeholders = ",".join("?" * len(file_unique_ids))
+    cur = conn.execute(
+        f"UPDATE files SET cleared_at = ? WHERE file_unique_id IN ({placeholders}) AND cleared_at IS NULL",
+        [_now(), *file_unique_ids],
+    )
+    conn.commit()
+    return cur.rowcount
 
 
 def file_by_unique_id(file_unique_id: str) -> dict | None:

--- a/tests/test_abuse_prepare.py
+++ b/tests/test_abuse_prepare.py
@@ -1,0 +1,188 @@
+"""Tests for report preparation batching + the cleared (not-problematic) state."""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+
+
+@pytest.fixture
+def abuse(tmp_path, monkeypatch):
+    import reverse_image_search_bot.settings as settings
+
+    db_path = tmp_path / "abuse.db"
+    monkeypatch.setattr(settings, "ABUSE_DB_PATH", db_path)
+    import reverse_image_search_bot.config.abuse as ab
+
+    ab._local.__dict__.clear()
+    ab._all_connections.clear()
+    importlib.reload(ab)
+    monkeypatch.setattr(ab, "ABUSE_DB_PATH", db_path)
+    ab._local.__dict__.clear()
+    ab._all_connections.clear()
+    return ab
+
+
+@pytest.fixture
+def env(abuse, tmp_path, monkeypatch):
+    """Upload dir + base URL configured; returns (abuse, updir, mkfiles)."""
+    from reverse_image_search_bot import settings
+
+    updir = tmp_path / "uploads"
+    updir.mkdir()
+    # "uploader" key present so importing server (→ uploaders) works standalone.
+    monkeypatch.setattr(settings, "UPLOADER", {"uploader": "local", "configuration": {"path": str(updir)}})
+    monkeypatch.setattr(settings, "REPORT_BASE_URL", "https://ris.naa.gg")
+
+    def mkfiles(user_id: int, n: int, prefix: str = "F"):
+        abuse.record_user(user_id, username=f"u{user_id}")
+        for i in range(n):
+            fid = f"{prefix}{i}"
+            abuse.record_file(fid, saved_filename=f"{fid}.jpg", user_id=user_id, file_type="photo")
+            (updir / f"{fid}.jpg").write_bytes(b"img-" + fid.encode())
+
+    return abuse, updir, mkfiles
+
+
+def test_prepare_caps_at_batch_and_reports_remaining(env):
+    from reverse_image_search_bot.abuse_report import prepare
+
+    abuse, _, mkfiles = env
+    mkfiles(1, prepare.PREPARE_BATCH + 5)
+    result = prepare.prepare_report(1)
+    assert result.ok
+    assert result.encrypted == prepare.PREPARE_BATCH
+    assert result.remaining == 5
+    assert len(abuse.blob_meta(result.report_uuid)) == prepare.PREPARE_BATCH
+    assert prepare.pending_files(result.report_uuid or "") == 5
+
+
+def test_extend_adds_next_batch_with_same_key(env):
+    from reverse_image_search_bot.abuse_report import crypto, prepare
+
+    abuse, _, mkfiles = env
+    mkfiles(1, prepare.PREPARE_BATCH + 3)
+    result = prepare.prepare_report(1)
+    assert result.remaining == 3
+
+    ext = prepare.extend_report(result.report_uuid or "", result.p1 or "")
+    assert ext.ok
+    assert ext.encrypted == 3
+    assert ext.remaining == 0
+    blobs = abuse.report_blobs(result.report_uuid)
+    assert len(blobs) == prepare.PREPARE_BATCH + 3
+    # New blobs decrypt with the ORIGINAL key.
+    key = crypto.derive_key(result.p1 or "")
+    last = blobs[-1]
+    plain = crypto.decrypt_file(bytes(last["nonce"]), bytes(last["ciphertext"]), key)
+    assert crypto.sha256_hex(plain) == last["plaintext_sha256"]
+
+
+def test_extend_rejects_wrong_key(env):
+    from reverse_image_search_bot.abuse_report import prepare
+
+    abuse, _, mkfiles = env
+    mkfiles(1, prepare.PREPARE_BATCH + 1)
+    result = prepare.prepare_report(1)
+    ext = prepare.extend_report(result.report_uuid or "", "totally-wrong-key")
+    assert not ext.ok
+    assert "P1" in (ext.error or "")
+    assert len(abuse.report_blobs(result.report_uuid)) == prepare.PREPARE_BATCH
+
+
+def test_cleared_files_excluded_from_prepare(env):
+    from reverse_image_search_bot.abuse_report import prepare
+
+    abuse, _, mkfiles = env
+    mkfiles(1, 3)
+    abuse.set_files_cleared(["F0", "F1"])
+    result = prepare.prepare_report(1)
+    assert result.ok
+    assert result.encrypted == 1
+    assert abuse.blob_meta(result.report_uuid)[0]["file_unique_id"] == "F2"
+
+
+def test_all_cleared_means_nothing_to_report(env):
+    from reverse_image_search_bot.abuse_report import prepare
+
+    abuse, _, mkfiles = env
+    mkfiles(1, 2)
+    abuse.set_files_cleared(["F0", "F1"])
+    result = prepare.prepare_report(1)
+    assert not result.ok
+    assert "cleared" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_cancel_with_clear_files_marks_round_cleared(env, monkeypatch):
+    from unittest.mock import AsyncMock
+
+    from reverse_image_search_bot.abuse_report import prepare, server
+
+    abuse, updir, mkfiles = env
+    mkfiles(1, 2)
+    result = prepare.prepare_report(1)
+    uuid = result.report_uuid
+
+    monkeypatch.setattr(server, "_admin_from_request", lambda req: 42)
+    req = MagicMock(spec=web.Request)
+    req.headers = {"X-Page-Secret": "pw"}
+    req.query = {}
+    req.match_info = {"uuid": uuid}
+    req.app = {"bot": None}
+    req.json = AsyncMock(return_value={"clear_files": True})
+    await server.api_cancel(req)
+
+    assert abuse.get_report(uuid)["status"] == abuse.REPORT_CANCELLED
+    # Disk files kept, but both marked cleared → a re-report finds nothing.
+    assert (updir / "F0.jpg").exists()
+    again = prepare.prepare_report(1)
+    assert not again.ok
+    assert "cleared" in (again.error or "")
+
+
+@pytest.mark.asyncio
+async def test_cancel_without_clear_keeps_files_reportable(env, monkeypatch):
+    from unittest.mock import AsyncMock
+
+    from reverse_image_search_bot.abuse_report import prepare, server
+
+    _abuse, _, mkfiles = env
+    mkfiles(1, 1)
+    result = prepare.prepare_report(1)
+
+    monkeypatch.setattr(server, "_admin_from_request", lambda req: 42)
+    req = MagicMock(spec=web.Request)
+    req.headers = {"X-Page-Secret": "pw"}
+    req.query = {}
+    req.match_info = {"uuid": result.report_uuid}
+    req.app = {"bot": None}
+    req.json = AsyncMock(return_value={"clear_files": False})
+    await server.api_cancel(req)
+
+    again = prepare.prepare_report(1)
+    assert again.ok  # still reportable
+
+
+def test_filing_clears_unselected_files(env):
+    """The api_submit clear step: unselected files in a filed round become cleared."""
+    abuse, _, mkfiles = env
+    mkfiles(1, 2)
+    abuse.create_report("u", 1, "")
+    abuse.add_report_blob(
+        "u", file_unique_id="F0", saved_filename="F0.jpg", nonce=b"n", ciphertext=b"c", plaintext_sha256="1"
+    )
+    abuse.add_report_blob(
+        "u", file_unique_id="F1", saved_filename="F1.jpg", nonce=b"n", ciphertext=b"c", plaintext_sha256="2"
+    )
+    ids = {m["file_unique_id"]: m["id"] for m in abuse.blob_meta("u")}
+    abuse.set_blob_selection("u", {ids["F0"]: "A1"})
+
+    # Mirror the api_submit clear step.
+    unselected = [b["file_unique_id"] for b in abuse.report_blobs("u") if not b["selected"]]
+    assert abuse.set_files_cleared(unselected) == 1
+    assert abuse.file_by_unique_id("F1")["cleared_at"] is not None
+    assert abuse.file_by_unique_id("F0")["cleared_at"] is None


### PR DESCRIPTION
Four report-pipeline fixes/improvements, one concern per commit.

## Channel `/report` found no uploaders (bug)
A channel post forwarded into the bot DM carries its source chat in `message.forward_origin`, which the provenance capture never read (only `effective_chat` / `sender_chat`). So those uploads were recorded with **no** `channel_id`, and `/report` on the channel found nothing to report. Now `forward_origin.chat` / `sender_chat` is captured too.

**Note:** ingest-time only — files uploaded before this fix can't retroactively gain channel provenance.

## "Preparing report" status + no timeouts
`/report` now replies **⏳ Preparing report…** immediately, runs the encrypt round via `asyncio.to_thread` (so a big round can't stall the webhook / report server or time out), then deletes the status message before the summary.

## Hard cap of 25 images + "Show more"
`prepare_report` encrypts at most **25** files per round and reports the remainder via `PrepareResult.remaining`. The webview gets a **Show more (N pending)** button under the gallery that calls the new `POST /report/{uuid}/api/extend` to prepare the next 25 and append them in place. The image key (P1) is verified against an existing blob before extending, so a typo can't split a report across two keys.

## "Cleared" (not-problematic) files
New `files.cleared_at` state. Cleared files are excluded from report preparation exactly like already-filed pieces — so `/report` on a user whose files are all cleared says "nothing to report", akin to the filed-report output.

Set from two places:
- **Cancel dialog** — the cancel confirmation is now a proper dialog with a checkbox to mark all images in the round as cleared.
- **On filing** — every file in the round the admin did **not** select is marked cleared automatically (filing is the decision that they're not problematic).

> "Non problematic" → shortened to **cleared** throughout.

## Tests
8 new tests (`tests/test_abuse_prepare.py`) covering batching, extend + key verification, cleared exclusion, and the cancel/filing clear paths. Full suite: 538 passed. `ruff` + `ty` clean; the report.html script passes `node --check`.
