### PR TITLE
Replace dead Google searchbyimage URL with Google Lens

### DIFF
--- a/reverse_image_search_bot/engines/__init__.py
+++ b/reverse_image_search_bot/engines/__init__.py
@@ -11,7 +11,7 @@ engines: list[GenericRISEngine] = [
     AnimeTraceEngine(),
     GenericRISEngine(
         "Google",
-        "https://www.google.com/searchbyimage?safe=off&sbisrc=tg&image_url={query_url}",
+        "https://lens.google.com/uploadbyurl?url={query_url}",
         "Google LLC is an American multinational technology company that specializes in Internet-related services and"
         " products.",
         "https://google.com/",


### PR DESCRIPTION
Google killed the legacy `/searchbyimage` endpoint — it now returns a plain 404 for everyone (verified via curl + headless browser). There is no account setting or parameter that revives it; the dessant/search-by-image extension hit the same wall (their googleImages engine now just shows a "Google replaced this with Lens" banner).

Replacement: `https://lens.google.com/uploadbyurl?url={query_url}` — takes an image URL, 303-redirects into Lens results. Verified working (303 → /search?vsrid=…&udm=26).

One-line change in `engines/__init__.py`. Full gate green (ruff, format, ty, 538 tests).
