### PR TITLE
fix: keep report-server AppRunner out of bot_data (silent persistence failure)

### DIFF
--- a/reverse_image_search_bot/bot.py
+++ b/reverse_image_search_bot/bot.py
@@ -315,6 +315,10 @@ async def post_init(app: Application) -> None:
             logger.warning("Failed to notify admin %d of startup", admin_id)
 
 
+# Module-level handle for the aiohttp report-server runner (see note below).
+_report_runner = None
+
+
 async def _start_report_server(app: Application) -> None:
     """Start the aiohttp report webview server if enabled.
 
@@ -329,7 +333,12 @@ async def _start_report_server(app: Application) -> None:
 
         runner = await start_report_server(bot=app.bot, bot_data=app.bot_data)
         if runner is not None:
-            app.bot_data["_report_runner"] = runner
+            # Keep a reference so the runner isn't garbage collected. Never put
+            # it in bot_data: an AppRunner is unpicklable, and one unpicklable
+            # value makes every PicklePersistence flush fail silently, freezing
+            # feedback_replies/banned_users on disk.
+            global _report_runner
+            _report_runner = runner
     except Exception:
         logger.warning("Failed to start report server", exc_info=True)
 

--- a/tests/test_report_runner_persistence.py
+++ b/tests/test_report_runner_persistence.py
@@ -1,0 +1,32 @@
+"""Regression: the report-server runner must never land in bot_data.
+
+An aiohttp AppRunner is unpicklable; one unpicklable value in bot_data makes
+every PicklePersistence flush fail silently (bot_data.pickle froze for 6 days
+in prod, dropping feedback reply mappings across restarts).
+"""
+
+import pickle
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from reverse_image_search_bot import bot as bot_module
+
+
+@pytest.mark.asyncio
+async def test_report_runner_not_in_bot_data():
+    app = MagicMock()
+    app.bot_data = {}
+    unpicklable_runner = MagicMock()
+
+    with (
+        patch.object(bot_module.settings, "REPORT_SERVER_ENABLED", True),
+        patch(
+            "reverse_image_search_bot.abuse_report.server.start_report_server",
+            AsyncMock(return_value=unpicklable_runner),
+        ),
+    ):
+        await bot_module._start_report_server(app)
+
+    assert bot_module._report_runner is unpicklable_runner
+    pickle.dumps(app.bot_data)  # must stay picklable


### PR DESCRIPTION
Stashing the aiohttp AppRunner in `bot_data` made every PicklePersistence flush fail silently (`TypeError: self._frozen cannot be converted to a Python object for pickling`, verified in the prod pod). `bot_data.pickle` froze at Jul 17 — the day the report server shipped — so `feedback_replies` mappings were lost on every pod restart and admin replies to feedback were silently dropped.

Fix: hold the runner in a module-level variable. It was only stored to keep it alive; nothing ever read it back.

Regression test asserts `bot_data` stays picklable after the report server starts.