### PR TITLE
feat: recover feedback reply target from the message itself

### DIFF
--- a/reverse_image_search_bot/commands/feedback.py
+++ b/reverse_image_search_bot/commands/feedback.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import html
 import logging
+import re
 from dataclasses import dataclass
 
 from telegram import Update
@@ -114,6 +115,27 @@ async def _send_to_user_or_chat(
         return False, "both_failed"
 
 
+def _target_from_reply_message(reply_to) -> FeedbackTarget | None:
+    """Recover the feedback target from the replied-to message itself.
+
+    Fallback for when the in-memory ``feedback_replies`` map is gone (bot
+    restart, lost persistence). The admin-facing feedback messages embed the
+    user id both as a ``tg://user?id=…`` text link and as ``(<user_id>)`` in
+    plain text — read it back from either.
+    """
+    for entity in reply_to.entities or ():
+        if entity.url and entity.url.startswith("tg://user?id="):
+            with_id = entity.url.removeprefix("tg://user?id=")
+            if with_id.isdigit():
+                uid = int(with_id)
+                return FeedbackTarget(user_id=uid, chat_id=uid)
+    match = re.search(r"\((\d+)\)", reply_to.text or "")
+    if match:
+        uid = int(match.group(1))
+        return FeedbackTarget(user_id=uid, chat_id=uid)
+    return None
+
+
 async def feedback_reply_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle replies to feedback messages — forwards between admin and user."""
     # The REPLY filter also matches edited messages, where update.message is None
@@ -127,14 +149,18 @@ async def feedback_reply_handler(update: Update, context: ContextTypes.DEFAULT_T
 
     fmap = _feedback_map(context)
     raw_target = fmap.get(key)
+    is_admin = chat_id in settings.ADMIN_IDS
     if raw_target is None:
-        return
+        # Map entry lost (restart / cleared persistence) — recover the user id
+        # from the feedback message itself. Admin replies to bot messages only.
+        if is_admin and reply_to.from_user and reply_to.from_user.id == context.bot.id:
+            raw_target = _target_from_reply_message(reply_to)
+        if raw_target is None:
+            return
 
     reply_text = update.message.text
     if not reply_text:
         return
-
-    is_admin = chat_id in settings.ADMIN_IDS
 
     if is_admin:
         # Admin → user

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -986,3 +986,84 @@ async def test_feedback_reply_handler_ignores_edited_message():
 
     # Previously raised AssertionError → must now be a no-op.
     await feedback_reply_handler(update, context)
+
+
+def _admin_reply_update(admin_id, reply_entities=(), reply_text_="", bot_id=999):
+    """Update: admin replying to a bot-authored feedback message."""
+    update = MagicMock()
+    update.effective_chat = MagicMock(id=admin_id)
+    reply_to = MagicMock()
+    reply_to.message_id = 42
+    reply_to.from_user = MagicMock(id=bot_id)
+    reply_to.entities = list(reply_entities)
+    reply_to.text = reply_text_
+    update.message = MagicMock()
+    update.message.reply_to_message = reply_to
+    update.message.text = "hello back"
+    update.message.reply_text = AsyncMock()
+    context = MagicMock()
+    context.bot.id = bot_id
+    context.bot.send_message = AsyncMock(return_value=MagicMock(message_id=77))
+    context.bot_data = {}
+    return update, context
+
+
+@pytest.mark.asyncio
+async def test_feedback_reply_fallback_recovers_id_from_text():
+    """Lost feedback_replies map (restart/stale pickle): the handler must
+    recover the user id from the '(<id>)' in the feedback message text."""
+    from reverse_image_search_bot.commands.feedback import feedback_reply_handler
+
+    admin_id = 713276361
+    update, context = _admin_reply_update(admin_id, reply_text_="📬 New Feedback\nFrom: Mona (87090172)\n\nhi")
+    with patch("reverse_image_search_bot.commands.feedback.settings") as mock_settings:
+        mock_settings.ADMIN_IDS = [admin_id]
+        await feedback_reply_handler(update, context)
+
+    assert context.bot.send_message.await_args_list[0].args[0] == 87090172
+    update.message.reply_text.assert_awaited()  # admin got a confirmation
+
+
+@pytest.mark.asyncio
+async def test_feedback_reply_fallback_prefers_user_entity():
+    from reverse_image_search_bot.commands.feedback import feedback_reply_handler
+
+    admin_id = 713276361
+    entity = MagicMock()
+    entity.url = "tg://user?id=87090172"
+    update, context = _admin_reply_update(admin_id, reply_entities=[entity])
+    with patch("reverse_image_search_bot.commands.feedback.settings") as mock_settings:
+        mock_settings.ADMIN_IDS = [admin_id]
+        await feedback_reply_handler(update, context)
+
+    assert context.bot.send_message.await_args_list[0].args[0] == 87090172
+
+
+@pytest.mark.asyncio
+async def test_feedback_reply_no_fallback_for_non_admin():
+    """A random user replying to some bot message with '(123)' in it must not
+    trigger a send."""
+    from reverse_image_search_bot.commands.feedback import feedback_reply_handler
+
+    update, context = _admin_reply_update(555, reply_text_="whatever (123)")
+    with patch("reverse_image_search_bot.commands.feedback.settings") as mock_settings:
+        mock_settings.ADMIN_IDS = [713276361]
+        await feedback_reply_handler(update, context)
+
+    context.bot.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_feedback_reply_no_fallback_for_non_bot_message():
+    """Admin replying to a NON-bot message (e.g. their own note containing
+    digits in parens) must not fire the fallback."""
+    from reverse_image_search_bot.commands.feedback import feedback_reply_handler
+
+    admin_id = 713276361
+    update, context = _admin_reply_update(admin_id, reply_text_="note to self (87090172)")
+    update.message.reply_to_message.from_user = MagicMock(id=admin_id)  # not the bot
+    with patch("reverse_image_search_bot.commands.feedback.settings") as mock_settings:
+        mock_settings.ADMIN_IDS = [admin_id]
+        await feedback_reply_handler(update, context)
+
+    context.bot.send_message.assert_not_awaited()


### PR DESCRIPTION
Admin replies to feedback were silently dropped when the `feedback_replies` map was lost (restart + the stale-pickle bug from #156). The feedback message already carries the user id (`tg://user?id=…` entity + `(<id>)` in text) — read it back as a fallback when the map has no entry. Only for admins replying to bot-authored messages, so a stray `(123)` in a random reply can't trigger a send.

Note: fallback targets the user's DM only (original group-chat fallback context isn't in the message text — acceptable, feedback is DM-based anyway).