### PR TITLE
chore: drop setuptools dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "httpx>=0.27",
     "PicImageSearch>=3.12.0",
     "yarl>=1.8.2",
-    "setuptools>=65.0.0,<82",
     "prometheus-client>=0.21.0",
     "lxml>=6.1",
     "ncmec-cybertip>=0.1.1",

--- a/reverse_image_search_bot/config/pixiv_config.py
+++ b/reverse_image_search_bot/config/pixiv_config.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 class PixivConfig:
-    _default_config: dict[str, None | str] = {
+    _default_config: dict[str, str | None] = {
         "refresh_token": None,
         "access_token": None,
     }

--- a/reverse_image_search_bot/engines/types.py
+++ b/reverse_image_search_bot/engines/types.py
@@ -5,7 +5,7 @@ from yarl import URL
 
 __all__ = ["InternalProviderData", "InternalResultData", "MetaData", "ProviderData", "ResultData"]
 
-InternalResultData = dict[str, str | int | URL | None | list[str] | set[str]]
+InternalResultData = dict[str, str | int | URL | list[str] | set[str] | None]
 ResultData = dict[str, str | int | URL | list[str] | set[str]]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1215,7 +1215,6 @@ dependencies = [
     { name = "pyopenssl" },
     { name = "python-magic" },
     { name = "python-telegram-bot", extra = ["job-queue", "webhooks"] },
-    { name = "setuptools" },
     { name = "user-agent" },
     { name = "validators" },
     { name = "yarl" },
@@ -1255,7 +1254,6 @@ requires-dist = [
     { name = "pyopenssl", specifier = ">=26.0.0" },
     { name = "python-magic", specifier = ">=0.4.24" },
     { name = "python-telegram-bot", extras = ["job-queue", "webhooks"], specifier = ">=22.6" },
-    { name = "setuptools", specifier = ">=65.0.0,<82" },
     { name = "user-agent", specifier = ">=0.1.10" },
     { name = "validators", specifier = ">=0.18.2" },
     { name = "yarl", specifier = ">=1.8.2" },
@@ -1296,15 +1294,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/76/3f72d8fc38c1cb77b38c56a70da9d0c17700cc1cc50f9649c9d3c8f5ba71/ruff-0.15.22-py3-none-win32.whl", hash = "sha256:e5ba0e4a13fd14abbed2a77b517a3911290c6c6c59ef67784328d1668fab76cf", size = 10789165, upload-time = "2026-07-16T15:14:04.16Z" },
     { url = "https://files.pythonhosted.org/packages/cb/46/4965251734c2b6fcdca1b1b187d20bcac3af0ee5b083b89c910bb961ce3a/ruff-0.15.22-py3-none-win_amd64.whl", hash = "sha256:9be63ba1eb936acd2d1342fb8337c356353706fce233b2a15a09a97037e6acde", size = 11938297, upload-time = "2026-07-16T15:14:07.316Z" },
     { url = "https://files.pythonhosted.org/packages/57/c9/e69b1ff4c8b69093ef08b8919ab767af0569666865b39c30a8795d88d3c6/ruff-0.15.22-py3-none-win_arm64.whl", hash = "sha256:e1168075b72158510839f250027659cdd78476f40507dd517892304c41318661", size = 11298172, upload-time = "2026-07-16T15:14:10.51Z" },
-]
-
-[[package]]
-name = "setuptools"
-version = "81.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`setuptools` was pinned (`>=65.0.0,<82`) back in #80 only to satisfy a `pkg_resources` import. Nothing in the codebase or in any installed dependency imports `pkg_resources`/`setuptools` any more, so the pin is dead weight — and it's what Dependabot #158 keeps trying to bump.

Removed it from `pyproject.toml` + `uv.lock`. This makes #158 obsolete.

Also fixes the two `RUF036` violations (`None` not last in a type union) in `engines/types.py` and `config/pixiv_config.py` — pre-existing code that the latest ruff now flags, which is what actually failed CI on #158.

Verified locally: `uv sync --all-groups` clean without setuptools, 543 tests pass, `uvx ruff@latest check .` and `ty check` both green.