### PR TITLE
fix: use synchronous=NORMAL so concurrent writers stop hitting "database is locked"

### DIFF
--- a/reverse_image_search_bot/config/abuse.py
+++ b/reverse_image_search_bot/config/abuse.py
@@ -40,6 +40,12 @@ def _get_conn() -> sqlite3.Connection:
         conn = sqlite3.connect(str(ABUSE_DB_PATH))
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA journal_mode=WAL")
+        # Network block storage fsyncs slowly: synchronous=FULL costs ~170 ms per
+        # commit here (p95 1.3 s), which piles writers up past busy_timeout and
+        # surfaces as "database is locked". NORMAL is the documented-safe pairing
+        # with WAL — durable across app crashes, only a power loss can lose the
+        # last commits.
+        conn.execute("PRAGMA synchronous=NORMAL")
         conn.execute("PRAGMA busy_timeout=15000")
         conn.execute("PRAGMA foreign_keys=ON")
         _ensure_schema(conn)

--- a/reverse_image_search_bot/config/db.py
+++ b/reverse_image_search_bot/config/db.py
@@ -41,6 +41,9 @@ def _get_conn() -> sqlite3.Connection:
         conn = sqlite3.connect(str(CONFIG_DB_PATH))
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA journal_mode=WAL")
+        # See config/abuse.py — synchronous=FULL is far too slow on the network
+        # PVC and starves concurrent writers past busy_timeout.
+        conn.execute("PRAGMA synchronous=NORMAL")
         conn.execute("PRAGMA busy_timeout=5000")
         _ensure_schema(conn)
         with _conn_lock:

--- a/tests/test_config_abuse.py
+++ b/tests/test_config_abuse.py
@@ -27,6 +27,15 @@ def abuse(tmp_path, monkeypatch):
     return ab
 
 
+def test_connection_uses_wal_with_synchronous_normal(abuse):
+    """synchronous=FULL fsyncs every commit (~170 ms on the network PVC), which
+    starves concurrent writers past busy_timeout -> "database is locked"."""
+    conn = abuse._get_conn()
+    assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+    # 1 == NORMAL. FULL (2) is the slow default this guards against.
+    assert conn.execute("PRAGMA synchronous").fetchone()[0] == 1
+
+
 def test_record_user_upserts_last_seen_wins(abuse):
     abuse.record_user(1, username="alice", first_name="Alice")
     abuse.record_user(1, username="alice2", first_name="Alice", last_name="B")


### PR DESCRIPTION
Fixes the `sqlite3.OperationalError: database is locked` errors coming from the report console.

## Root cause

Not what it looked like. The lock errors landed at **18:03:32–39**, *before* the submit at 18:04:02 — so `finish()` holding a writer across the NCMEC call was ruled out. Three earlier theories were tested and discarded: the previous `fix/abuse-db-write-lock` work is already merged (WAL, `busy_timeout=15000`, single-transaction writes all present), and `_ensure_schema` measures 92 ms on a real DB copy.

The tell was in the access log: requests arrived at :14, :17, :21, :24 and completed in **23 s, 15 s, 15 s, 15 s** — the 15 s ones being exactly `busy_timeout`. Then latency *decreased*: 19 s → 11 s → 5 s. A queue draining, not a deadlock.

SQLite defaults to `synchronous=FULL`, which fsyncs on every commit. Measured in the prod pod against a copy of the real DB on the Vultr block-storage PVC:

| | median | p95 | max |
|---|---|---|---|
| FULL (current) | **173 ms** | 1.3 s | 1.7 s |
| NORMAL | **0.1 ms** | 0.5 ms | 59 ms |

Six concurrent writers under FULL: 17.1 s total with a **13.8 s worst-case wait** — a whisker under the 15 s timeout. The same workload under NORMAL: **0.2 s**. Network-storage fsync is ~1700× slower than local and nothing was compensating.

Rapidly tapping the A1/A2/B1/B2 classification buttons on a 4-image report was enough to tip it over.

## Why NORMAL is safe

In WAL mode `synchronous=NORMAL` **cannot corrupt the database**. Application crashes, Python exceptions, OOM kills, `kubectl rollout restart`, even an OS crash all recover cleanly, because the WAL is replayed on next open. Only a host power loss can lose the most recent transactions — never file integrity. `WAL` + `NORMAL` is SQLite's documented standard pairing.

## Changes

- `config/abuse.py` and `config/db.py` — both live on the same PVC, both had the default.
- Regression test asserting WAL + `synchronous=1`.

`synchronous` is a per-connection PRAGMA, not stored in the file: takes effect on restart, no migration, instantly revertible.
