### PR TITLE
perf: index the two user lookups that were full table scans

### DIFF
--- a/reverse_image_search_bot/config/abuse.py
+++ b/reverse_image_search_bot/config/abuse.py
@@ -212,6 +212,18 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     _add_column_if_missing(conn, "report_blobs", "video_sha256", "TEXT")
     _add_column_if_missing(conn, "report_blobs", "video_filename", "TEXT")
     _add_column_if_missing(conn, "report_blobs", "created_at", "INTEGER")
+
+    # User lookup indexes. Created AFTER every column migration above — an old DB
+    # has no `username` column when this function starts, and indexing a
+    # not-yet-added column fails. Measured on a copy of the production DB
+    # (5.8k users): username lookup 1.07 ms -> 0.08 ms, banned listing
+    # 1.57 ms -> 0.12 ms; both were full table scans. The username index must
+    # carry the query's NOCASE collation or SQLite can't use it. The banned
+    # index is partial — banned users are a tiny fraction of the table.
+    _add_column_if_missing(conn, "users", "username", "TEXT")
+    _add_column_if_missing(conn, "users", "banned_at", "INTEGER")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_users_username_nocase ON users(username COLLATE NOCASE)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_users_banned ON users(banned_at) WHERE banned_at IS NOT NULL")
     conn.commit()
 
 

--- a/tests/test_config_abuse.py
+++ b/tests/test_config_abuse.py
@@ -27,6 +27,29 @@ def abuse(tmp_path, monkeypatch):
     return ab
 
 
+def test_lookup_queries_use_indexes_not_scans(abuse):
+    """Both lookups were full table scans on the real DB. The username index
+    only works if it carries the query's NOCASE collation."""
+    abuse.record_user(1, username="alice")
+    abuse.set_banned(2, True)
+    conn = abuse._get_conn()
+
+    plan = " ".join(
+        r["detail"]
+        for r in conn.execute(
+            "EXPLAIN QUERY PLAN SELECT user_id FROM users WHERE username = ? COLLATE NOCASE", ("alice",)
+        )
+    )
+    assert "SCAN" not in plan, plan
+    assert "idx_users_username_nocase" in plan, plan
+
+    plan = " ".join(
+        r["detail"] for r in conn.execute("EXPLAIN QUERY PLAN SELECT user_id FROM users WHERE banned_at IS NOT NULL")
+    )
+    assert "SCAN" not in plan, plan
+    assert "idx_users_banned" in plan, plan
+
+
 def test_record_user_upserts_last_seen_wins(abuse):
     abuse.record_user(1, username="alice", first_name="Alice")
     abuse.record_user(1, username="alice2", first_name="Alice", last_name="B")


### PR DESCRIPTION
Indexes the two user lookups that were doing full table scans.

## Measurements

`EXPLAIN QUERY PLAN` + timings across 8 hot queries, run against a copy of the production `abuse.db` (5,847 users / 26,797 files) taken read-only via `VACUUM INTO` — the live DB was never touched.

The `users` table had **zero indexes** (confirmed directly on prod: `PRAGMA index_list(users)` → empty).

| query | before | after |
|---|---|---|
| `find_user_by_username` | 1.07 ms `SCAN users` | **0.08 ms** covering index |
| `banned_users` listing | 1.57 ms `SCAN users` | **0.12 ms** covering index |

## Two subtleties

- The username index **must** carry `COLLATE NOCASE` to match the query's collation. Without it SQLite builds the index and then silently ignores it.
- `username` and `banned_at` were **never backfilled** onto pre-existing DBs — they only appear in the fresh `CREATE TABLE`, so index creation would crash on an old DB. The missing forward migrations are added, and index creation is placed after all column migrations (same ALTER-before-index ordering rule that already applies here).

## Rejected

A composite `(user_id, upload_time)` index for `files_for_user` was implemented, measured, and **dropped**. It removed the `USE TEMP B-TREE FOR ORDER BY` but only moved 18 ms → 17 ms: the cost is fetching 1329 rows for the single heaviest user, not sorting. A typical user's lookup is already **0.15 ms**. Not worth the write-side cost.

The third scan (`list_reports_join`) is 0.54 ms over 40 reports — left alone.

## Cost

575 ms one-time index build at startup on a prod-sized DB, then a no-op forever (verified idempotent: 0.1 ms on second run).

A test asserts the query **plans**, so dropping the NOCASE collation later fails the suite instead of quietly regressing to a scan.

Note this is a second-order win — #162 is the change that actually resolves the `database is locked` errors.
