### PR TITLE
feat: route error notifications to a configurable chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ All configuration is done via environment variables.
 | Variable | Default | Description |
 |---|---|---|
 | `ADMIN_IDS` | — | Comma-separated Telegram user IDs with admin access |
+| `ERROR_CHAT_ID` | — | Chat to send WARNING+ log records to; when unset they are DMed to `ADMIN_IDS`. Channel/supergroup ids need the `-100` prefix |
 | `ANILIST_TOKEN` | — | AniList OAuth token (raises rate limit from 90 to 120 req/min) |
 | `MODE_ACTIVE` | `polling` | Bot mode: `polling` or `webhook` |
 | `CONCURRENT_UPDATES` | `16` | Number of concurrent update handlers |

--- a/reverse_image_search_bot/bot.py
+++ b/reverse_image_search_bot/bot.py
@@ -58,7 +58,10 @@ application: Application | None = None
 
 
 class TelegramLogHandler(logging.Handler):
-    """Forward WARNING+ log records to Telegram admin chats.
+    """Forward WARNING+ log records to Telegram.
+
+    Records go to ``settings.ERROR_CHAT_ID`` when it is set, otherwise they are
+    DMed to every id in ``settings.ADMIN_IDS``.
 
     Because this handler is invoked from arbitrary threads (via the logging
     framework), we schedule coroutines on the running event loop with
@@ -81,9 +84,10 @@ class TelegramLogHandler(logging.Handler):
         try:
             prefix = self.prefixes.get(record.levelno, "")
             msg = f"{prefix} {self.format(record)}"
-            for admin in settings.ADMIN_IDS:
+            targets = [settings.ERROR_CHAT_ID] if settings.ERROR_CHAT_ID else settings.ADMIN_IDS
+            for target in targets:
                 if len(msg) <= 4096:
-                    coro = self.bot.send_message(admin, msg, parse_mode=ParseMode.HTML)
+                    coro = self.bot.send_message(target, msg, parse_mode=ParseMode.HTML)
                 else:
                     raw_text = super().format(record)
                     filename = f"error_{int(record.created)}_{record.levelname.lower()}.log"
@@ -92,7 +96,7 @@ class TelegramLogHandler(logging.Handler):
                     suffix = "\n... [truncated]"
                     caption = msg[: 1024 - len(suffix)] + suffix if len(msg) > 1024 else msg
                     coro = self.bot.send_document(
-                        admin, log_data, filename=filename, caption=caption, parse_mode=ParseMode.HTML
+                        target, log_data, filename=filename, caption=caption, parse_mode=ParseMode.HTML
                     )
                 asyncio.run_coroutine_threadsafe(coro, self.loop)
         except Exception:

--- a/reverse_image_search_bot/settings.py
+++ b/reverse_image_search_bot/settings.py
@@ -46,6 +46,11 @@ UPLOADER: dict[str, Any] = {
 
 ADMIN_IDS = get_env_list("ADMIN_IDS")
 
+# Chat that WARNING+ log records are delivered to. When unset they are DMed to
+# ADMIN_IDS instead. Channel/supergroup ids carry the -100 prefix.
+_error_chat_id = os.getenv("ERROR_CHAT_ID", "").strip()
+ERROR_CHAT_ID = int(_error_chat_id) if _error_chat_id else None
+
 SAUCENAO_API = required_env("SAUCENAO_API")
 TRACE_API = required_env("TRACE_API")
 ANILIST_TOKEN = os.getenv("ANILIST_TOKEN")

--- a/tests/test_telegram_log_handler.py
+++ b/tests/test_telegram_log_handler.py
@@ -1,0 +1,59 @@
+"""Tests for TelegramLogHandler delivery targets (admins vs ERROR_CHAT_ID)."""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from reverse_image_search_bot.bot import TelegramLogHandler
+
+
+@pytest.fixture
+def record():
+    return logging.LogRecord(
+        name="test", level=logging.ERROR, pathname=__file__, lineno=1, msg="boom", args=(), exc_info=None
+    )
+
+
+@pytest.fixture
+def handler():
+    return TelegramLogHandler(bot=MagicMock(), loop=MagicMock(), level=logging.WARNING)
+
+
+class TestTelegramLogHandlerTargets:
+    @patch("reverse_image_search_bot.bot.asyncio.run_coroutine_threadsafe")
+    @patch("reverse_image_search_bot.bot.settings")
+    def test_unset_error_chat_sends_to_admins(self, mock_settings, _run, handler, record):
+        mock_settings.ERROR_CHAT_ID = None
+        mock_settings.ADMIN_IDS = [111, 222]
+
+        handler.emit(record)
+
+        targets = [call.args[0] for call in handler.bot.send_message.call_args_list]
+        assert targets == [111, 222]
+
+    @patch("reverse_image_search_bot.bot.asyncio.run_coroutine_threadsafe")
+    @patch("reverse_image_search_bot.bot.settings")
+    def test_set_error_chat_sends_only_there(self, mock_settings, _run, handler, record):
+        mock_settings.ERROR_CHAT_ID = -1004389046822
+        mock_settings.ADMIN_IDS = [111, 222]
+
+        handler.emit(record)
+
+        targets = [call.args[0] for call in handler.bot.send_message.call_args_list]
+        assert targets == [-1004389046822]
+
+    @patch("reverse_image_search_bot.bot.asyncio.run_coroutine_threadsafe")
+    @patch("reverse_image_search_bot.bot.settings")
+    def test_long_record_documents_go_to_error_chat(self, mock_settings, _run, handler):
+        mock_settings.ERROR_CHAT_ID = -1004389046822
+        mock_settings.ADMIN_IDS = [111]
+        long_record = logging.LogRecord(
+            name="test", level=logging.ERROR, pathname=__file__, lineno=1, msg="x" * 5000, args=(), exc_info=None
+        )
+
+        handler.emit(long_record)
+
+        handler.bot.send_message.assert_not_called()
+        targets = [call.args[0] for call in handler.bot.send_document.call_args_list]
+        assert targets == [-1004389046822]


### PR DESCRIPTION
Routes error notifications to a dedicated chat instead of DMing the admins.

## Change

`TelegramLogHandler.emit()` DMed every WARNING+ log record to each id in `ADMIN_IDS`. It now sends to `ERROR_CHAT_ID` when that is set, and falls back to `ADMIN_IDS` when it is unset or empty — so existing deployments are byte-for-byte unchanged.

The whole change is one line at the single delivery point:

```python
targets = [settings.ERROR_CHAT_ID] if settings.ERROR_CHAT_ID else settings.ADMIN_IDS
```

The send/`send_document`/truncation behaviour below it is untouched.

## Placement

This is in `bot.py` (public repo), not `admin_handlers.py` (deploy-only). `admin_handlers.py` does message *forwarding*; the error path is `TelegramLogHandler`, which lives in public `bot.py` — deploy's richer `bot.py` override contains a byte-identical copy of the class. Shared logic belongs upstream, and the deploy fork picks it up on the next `upstream → deploy` merge.

## Deploy config

Set in the k8s configmap, not hardcoded:

```
ERROR_CHAT_ID=-1004389046822
```

Channel/supergroup ids need the Bot API `-100` prefix — internal id `4389046822` becomes `-1004389046822`.

## Tests

Both branches are covered: var set → delivered to the error chat and **not** to the admins; var unset → delivered to admins exactly as before. Verified the tests actually gate the change by stashing `bot.py` and confirming they fail without it.
