### PR TITLE
perf: run one-off migrations only when they can still do something

### DIFF
--- a/reverse_image_search_bot/config/abuse.py
+++ b/reverse_image_search_bot/config/abuse.py
@@ -61,11 +61,17 @@ def _close_all_connections() -> None:
 atexit.register(_close_all_connections)
 
 
-def _add_column_if_missing(conn: sqlite3.Connection, table: str, column: str, decl: str) -> None:
-    """Idempotently add a column to an existing table (simple forward migration)."""
+def _add_column_if_missing(conn: sqlite3.Connection, table: str, column: str, decl: str) -> bool:
+    """Idempotently add a column to an existing table (simple forward migration).
+
+    Returns True when the column was actually added, so a caller can run a
+    one-shot backfill exactly once instead of on every connection.
+    """
     cols = {row["name"] for row in conn.execute(f"PRAGMA table_info({table})")}
     if column not in cols:
         conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {decl}")
+        return True
+    return False
 
 
 def _ensure_schema(conn: sqlite3.Connection) -> None:
@@ -126,12 +132,15 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
 
     # created_at on every table (reports already has one). Backfill existing rows
     # from the closest pre-existing timestamp so old rows aren't left NULL.
-    _add_column_if_missing(conn, "users", "created_at", "INTEGER")
-    _add_column_if_missing(conn, "chats", "created_at", "INTEGER")
-    _add_column_if_missing(conn, "files", "created_at", "INTEGER")
-    conn.execute("UPDATE users SET created_at = first_seen WHERE created_at IS NULL")
-    conn.execute("UPDATE chats SET created_at = first_seen WHERE created_at IS NULL")
-    conn.execute("UPDATE files SET created_at = upload_time WHERE created_at IS NULL")
+    # Each backfill is gated on its ALTER: it is only meaningful the one time the
+    # column appears. Probing for leftover NULLs instead would re-scan the whole
+    # table on every connection to discover there is nothing to do.
+    if _add_column_if_missing(conn, "users", "created_at", "INTEGER"):
+        conn.execute("UPDATE users SET created_at = first_seen WHERE created_at IS NULL")
+    if _add_column_if_missing(conn, "chats", "created_at", "INTEGER"):
+        conn.execute("UPDATE chats SET created_at = first_seen WHERE created_at IS NULL")
+    if _add_column_if_missing(conn, "files", "created_at", "INTEGER"):
+        conn.execute("UPDATE files SET created_at = upload_time WHERE created_at IS NULL")
 
     # A user's Telegram bio (fetched best-effort at report time) and a per-file
     # caption (text sent alongside the media, if any) — both reportable to NCMEC.
@@ -145,8 +154,13 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     # real videos. Documents/stickers are left 0 (can't know retroactively; the
     # safe default is "not a video" so we never invent a bogus video piece). Rows
     # that already have a fetched video keep it via video_filename regardless.
-    _add_column_if_missing(conn, "files", "is_video", "INTEGER NOT NULL DEFAULT 0")
-    conn.execute("UPDATE files SET is_video = 1 WHERE file_type IN ('video', 'gif')")
+    #
+    # Gated on the column being NEW rather than on the rows, because is_video is
+    # set per-file at ingest: a legitimately-0 'video' row would otherwise make
+    # the backfill re-run (and re-scan) on every connection forever.
+    is_video_added = _add_column_if_missing(conn, "files", "is_video", "INTEGER NOT NULL DEFAULT 0")
+    if is_video_added:
+        conn.execute("UPDATE files SET is_video = 1 WHERE file_type IN ('video', 'gif')")
 
     # A file the admin marked as NOT problematic ("cleared") — excluded from
     # report preparation just like already-filed pieces. Set from the cancel
@@ -200,11 +214,18 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     conn.execute("CREATE INDEX IF NOT EXISTS idx_blobs_report ON report_blobs(report_uuid)")
     # One blob per file per report. A raced extend (e.g. client retry during a
     # locked-DB episode) used to insert duplicates; drop any existing ones (keep
-    # the lowest id) so the unique index can be created on old DBs.
-    conn.execute(
-        "DELETE FROM report_blobs WHERE id NOT IN "
-        "(SELECT MIN(id) FROM report_blobs GROUP BY report_uuid, file_unique_id)"
+    # the lowest id) so the unique index can be created on old DBs. Once that
+    # index exists it enforces the constraint, so duplicates are impossible and
+    # the scanning DELETE never needs to run again.
+    has_unique_blob_index = (
+        conn.execute("SELECT 1 FROM sqlite_master WHERE type='index' AND name='idx_blobs_report_file'").fetchone()
+        is not None
     )
+    if not has_unique_blob_index:
+        conn.execute(
+            "DELETE FROM report_blobs WHERE id NOT IN "
+            "(SELECT MIN(id) FROM report_blobs GROUP BY report_uuid, file_unique_id)"
+        )
     conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_blobs_report_file ON report_blobs(report_uuid, file_unique_id)")
     # Forward migration: video columns for reports created before video support.
     _add_column_if_missing(conn, "report_blobs", "video_path", "TEXT")

--- a/tests/test_config_abuse.py
+++ b/tests/test_config_abuse.py
@@ -27,6 +27,53 @@ def abuse(tmp_path, monkeypatch):
     return ab
 
 
+def test_migrations_skip_scans_when_already_applied(abuse):
+    """_ensure_schema runs on every new thread's connection. Once the DB is
+    migrated the backfills are no-ops, but SQLite still scans the whole table to
+    find that out — so they must be probe-gated, not run unconditionally."""
+    abuse.record_user(1, username="alice")
+    abuse.record_file("F1", saved_filename="F1.mp4", user_id=1, file_type="video")
+    conn = abuse._get_conn()
+
+    ran: list[str] = []
+    # set_trace_callback sees every statement SQLite actually executes;
+    # sqlite3.Connection.execute itself is read-only and can't be patched.
+    conn.set_trace_callback(lambda sql: ran.append(" ".join(sql.split())))
+    try:
+        abuse._ensure_schema(conn)
+    finally:
+        conn.set_trace_callback(None)
+
+    writes = [s for s in ran if s.upper().startswith(("UPDATE", "DELETE"))]
+    assert writes == [], f"re-ran completed migrations: {writes}"
+
+
+def test_backfill_runs_when_column_is_first_added(abuse, tmp_path):
+    """The gate must not skip a backfill on a DB that genuinely needs it."""
+    import sqlite3
+
+    db = tmp_path / "old.db"
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE users (user_id INTEGER PRIMARY KEY, first_seen INTEGER, last_seen INTEGER)")
+    conn.execute(
+        "CREATE TABLE files (file_unique_id TEXT PRIMARY KEY, saved_filename TEXT NOT NULL, "
+        "original_filename TEXT, file_type TEXT, upload_time INTEGER NOT NULL, "
+        "user_id INTEGER NOT NULL REFERENCES users(user_id))"
+    )
+    conn.execute("INSERT INTO users (user_id, first_seen, last_seen) VALUES (1, 42, 42)")
+    conn.execute("INSERT INTO files VALUES ('V', 'V.mp4', NULL, 'video', 7, 1)")
+    conn.execute("INSERT INTO files VALUES ('P', 'P.jpg', NULL, 'photo', 7, 1)")
+    conn.commit()
+
+    abuse._ensure_schema(conn)
+
+    assert conn.execute("SELECT created_at FROM users WHERE user_id = 1").fetchone()[0] == 42
+    rows = dict(conn.execute("SELECT file_unique_id, is_video FROM files").fetchall())
+    assert rows == {"V": 1, "P": 0}
+    conn.close()
+
+
 def test_record_user_upserts_last_seen_wins(abuse):
     abuse.record_user(1, username="alice", first_name="Alice")
     abuse.record_user(1, username="alice2", first_name="Alice", last_name="B")


### PR DESCRIPTION
Stops re-running completed one-off migrations on every database connection.

## Problem

`_ensure_schema` runs on **every new thread's connection**, and `asyncio.to_thread` creates threads on demand. Five one-off backfills ran unconditionally each time. They are no-ops on a migrated DB — but SQLite still scans the entire table to establish that there is nothing to do.

Measured on a copy of the production `abuse.db` in the prod pod:

| statement | plan | time |
|---|---|---|
| `files is_video` backfill | `SCAN files` | 14.21 ms |
| `files created_at` backfill | `SCAN files` | 11.32 ms |
| `users created_at` backfill | `SCAN users` | 1.37 ms |
| blob dedupe DELETE | `SCAN report_blobs` | 0.36 ms |
| `chats created_at` backfill | `SCAN chats` | 0.24 ms |
| **total per connection** | | **27.5 ms** |

## Fix

Each backfill is gated on its own `ALTER`: `_add_column_if_missing` now returns whether it actually added the column, so the backfill runs exactly once — on the connection where the column first appears.

**27.5 ms → 0.4 ms per connection** (68×).

## Approach rejected

Probing for leftover rows first (`SELECT 1 ... WHERE created_at IS NULL LIMIT 1`) was implemented and measured, then dropped: `IS NULL` still scans the whole table to find no rows, so it only got 27.5 ms down to ~14 ms.

`is_video` **cannot** be row-probed at all. It is set per-file at ingest, independent of `file_type`, so a `'video'` row that is legitimately `0` would re-trigger the backfill on every connection forever. The ALTER gate is the only correct one — caught by the test asserting no writes re-run.

The blob dedupe `DELETE` is gated on the existence of `idx_blobs_report_file` instead: that unique index is precisely what the DELETE exists to make creatable, and once it exists duplicates cannot be inserted.

## Tests

- Trace-callback test asserting a migrated DB executes **zero** `UPDATE`/`DELETE` statements in `_ensure_schema` (uses `set_trace_callback` — `sqlite3.Connection.execute` is read-only and can't be patched).
- Test that an genuinely old-schema DB still backfills correctly: `created_at` populated from `first_seen`, and `is_video` set to 1 for video/gif but left 0 for photo.

Verified end-to-end against a real old-schema DB: correct migration on first open, zero writes on the second connection.
