### PR TITLE
feat(abuse): take a user's files offline while a report is open

### DIFF
--- a/reverse_image_search_bot/abuse_report/prepare.py
+++ b/reverse_image_search_bot/abuse_report/prepare.py
@@ -13,6 +13,7 @@ upload path from ``settings``.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from pathlib import Path
 
 from reverse_image_search_bot import settings
@@ -25,6 +26,38 @@ logger = logging.getLogger("abuse.prepare")
 def upload_dir() -> Path | None:
     p = settings.UPLOADER.get("configuration", {}).get("path")
     return Path(p) if p else None
+
+
+def cipher_dir(report_uuid: str) -> Path | None:
+    """Directory holding a report's encrypted image ciphertext (under the PVC).
+
+    Mirrors how videos are stored: only FILED files' bytes ever move into
+    SQLite, so an open report keeps its ciphertext on disk and the DB row just
+    points at it.
+    """
+    updir = upload_dir()
+    if updir is None:
+        return None
+    d = updir / "report_files" / report_uuid
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def blob_ciphertext(blob: dict) -> bytes | None:
+    """The encrypted bytes of a blob, wherever they live (disk or DB).
+
+    Open reports keep ciphertext on disk (``cipher_path``); filed ones hold it
+    in the ``ciphertext`` column. Returns None if the on-disk file is missing.
+    """
+    path = blob.get("cipher_path")
+    if path:
+        updir = upload_dir()
+        if updir is None:
+            return None
+        fp = updir / path
+        return fp.read_bytes() if fp.is_file() else None
+    ct = blob.get("ciphertext")
+    return bytes(ct) if ct else None
 
 
 def resolve_user(arg: str) -> int | None:
@@ -98,15 +131,27 @@ def _present_files(user_id: int) -> tuple[list, int, int]:
     return present, len(files), cleared
 
 
-def _encrypt_and_remove(report_uuid: str, batch: list, key: bytes) -> int:
+def _encrypt_and_remove(
+    report_uuid: str, batch: list, key: bytes, progress: Callable[[int, int], None] | None = None
+) -> int:
     """Encrypt (file_row, path) pairs into report blobs, deleting each plaintext.
 
-    The plaintext is unlinked only AFTER its blob is committed, so a crash
-    mid-round can never lose a file: at worst it stays on disk and is picked up
-    again. Taking the file offline is the point of preparing a report — while a
-    round is open the material must not be publicly reachable.
+    The ciphertext is written to disk (``report_files/<uuid>/``) and the DB row
+    only points at it — nothing enters SQLite until the report is actually
+    FILED. The plaintext is unlinked only AFTER its ciphertext is on disk and
+    the row committed, so a crash mid-round can never lose a file: at worst it
+    stays on disk and is picked up again. Taking the file offline is the point
+    of preparing a report — while a round is open the material must not be
+    publicly reachable.
+
+    ``progress`` (optional) is called with ``(done, total)`` after each file;
+    a big user/group takes a while and the admin wants to see it move.
     """
+    cdir = cipher_dir(report_uuid)
+    if cdir is None:
+        return 0
     encrypted = 0
+    total = len(batch)
     for f, fp in batch:
         try:
             data = fp.read_bytes()
@@ -114,12 +159,14 @@ def _encrypt_and_remove(report_uuid: str, batch: list, key: bytes) -> int:
             logger.warning("failed to read %s", fp, exc_info=True)
             continue
         nonce, ct = crypto.encrypt_file(data, key)
+        cipher_name = f"{f['file_unique_id']}.enc"
+        (cdir / cipher_name).write_bytes(ct)
         abuse.add_report_blob(
             report_uuid,
             file_unique_id=f["file_unique_id"],
             saved_filename=f["saved_filename"],
             nonce=nonce,
-            ciphertext=ct,
+            cipher_path=f"report_files/{report_uuid}/{cipher_name}",
             plaintext_sha256=crypto.sha256_hex(data),
         )
         try:
@@ -127,6 +174,8 @@ def _encrypt_and_remove(report_uuid: str, batch: list, key: bytes) -> int:
         except Exception:
             logger.warning("failed to remove plaintext %s", fp, exc_info=True)
         encrypted += 1
+        if progress is not None:
+            progress(encrypted, total)
     return encrypted
 
 
@@ -144,8 +193,12 @@ def restore_report_files(report_uuid: str, p1: str) -> str | None:
     key = crypto.derive_key(p1)
     plaintexts: list[tuple[Path, bytes]] = []
     for b in abuse.report_blobs(report_uuid):
+        ct = blob_ciphertext(b)
+        if ct is None:
+            logger.warning("ciphertext missing for blob %s — cannot restore", b["id"])
+            continue
         try:
-            data = crypto.decrypt_file(bytes(b["nonce"]), bytes(b["ciphertext"]), key)
+            data = crypto.decrypt_file(bytes(b["nonce"]), ct, key)
         except Exception:
             return "image key (P1) incorrect"
         if crypto.sha256_hex(data) != b["plaintext_sha256"]:
@@ -159,12 +212,33 @@ def restore_report_files(report_uuid: str, p1: str) -> str | None:
     return None
 
 
+def purge_cipher_dir(report_uuid: str) -> None:
+    """Delete a report's on-disk ciphertext directory (and its contents)."""
+    updir = upload_dir()
+    if updir is None:
+        return
+    d = updir / "report_files" / report_uuid
+    if not d.is_dir():
+        return
+    for fp in d.iterdir():
+        try:
+            fp.unlink()
+        except Exception:
+            logger.warning("failed to delete ciphertext %s", fp, exc_info=True)
+    try:
+        d.rmdir()
+    except Exception:
+        logger.warning("failed to remove cipher dir %s", d, exc_info=True)
+
+
 def delete_user_files(user_id: int) -> int:
     """Delete every on-disk file of a user. Returns how many were removed.
 
     Banning is the end of the line: nothing of theirs stays publicly reachable.
-    Encrypted blobs of an already-filed report are untouched — those live in the
-    DB and are the evidence.
+    That includes the still-ENCRYPTED leftovers of any report of theirs that was
+    never filed — an open round's ciphertext is deleted along with its blob rows.
+    Filed reports are untouched: their ciphertext moved into the DB at filing
+    time and is the evidence.
     """
     updir = upload_dir()
     if updir is None:
@@ -178,10 +252,15 @@ def delete_user_files(user_id: int) -> int:
                 removed += 1
         except Exception:
             logger.warning("failed to delete %s on ban", fp, exc_info=True)
+    for rep in abuse.reports_for_user(user_id):
+        if rep["status"] == abuse.REPORT_FILED:
+            continue
+        abuse.purge_report_blobs(rep["report_uuid"])
+        purge_cipher_dir(rep["report_uuid"])
     return removed
 
 
-def prepare_report(user_id: int) -> PrepareResult:
+def prepare_report(user_id: int, progress: Callable[[int, int], None] | None = None) -> PrepareResult:
     """Gather → encrypt → create a ``ready`` report for ``user_id``.
 
     Returns a :class:`PrepareResult`. On success it carries the new
@@ -190,8 +269,12 @@ def prepare_report(user_id: int) -> PrepareResult:
 
     EVERY on-disk file of the user is encrypted into the report and its
     plaintext removed from disk, so opening a report takes the material offline
-    for as long as the round is open. Cancelling restores the files; filing
-    keeps the reported ones encrypted and deletes the rest.
+    for as long as the round is open. The ciphertext lives on disk too — only
+    FILED files ever enter the DB. Cancelling restores the files; filing moves
+    the reported ciphertext into the DB and deletes the rest.
+
+    ``progress`` (optional) receives ``(done, total)`` per encrypted file — a
+    user or group with many uploads takes a while.
     """
     if not settings.REPORT_BASE_URL:
         return PrepareResult(error="Report server is not configured (REPORT_BASE_URL unset).")
@@ -234,6 +317,6 @@ def prepare_report(user_id: int) -> PrepareResult:
     key = crypto.derive_key(p1)
 
     abuse.create_report(report_uuid, user_id, "")
-    encrypted = _encrypt_and_remove(report_uuid, present, key)
+    encrypted = _encrypt_and_remove(report_uuid, present, key, progress)
     abuse.set_report_status(report_uuid, abuse.REPORT_READY)
     return PrepareResult(report_uuid=report_uuid, p1=p1, encrypted=encrypted)

--- a/reverse_image_search_bot/abuse_report/prepare.py
+++ b/reverse_image_search_bot/abuse_report/prepare.py
@@ -21,10 +21,6 @@ from reverse_image_search_bot.config import abuse
 
 logger = logging.getLogger("abuse.prepare")
 
-# Hard cap on files encrypted into a report round at once. Reports with more
-# on-disk uploads get a "show more" in the webview that prepares the next batch.
-PREPARE_BATCH = 25
-
 
 def upload_dir() -> Path | None:
     p = settings.UPLOADER.get("configuration", {}).get("path")
@@ -58,7 +54,6 @@ class PrepareResult:
         report_uuid: str | None = None,
         p1: str | None = None,
         encrypted: int = 0,
-        remaining: int = 0,
         error: str | None = None,
         existing_uuid: str | None = None,
         filed_uuid: str | None = None,
@@ -67,9 +62,6 @@ class PrepareResult:
         self.report_uuid = report_uuid
         self.p1 = p1
         self.encrypted = encrypted
-        # Files still on disk but beyond the PREPARE_BATCH cap — preparable via
-        # the webview's "show more".
-        self.remaining = remaining
         self.error = error
         self.existing_uuid = existing_uuid
         # Set when the failure is "already filed with NCMEC" so the caller can
@@ -106,8 +98,14 @@ def _present_files(user_id: int) -> tuple[list, int, int]:
     return present, len(files), cleared
 
 
-def _encrypt_batch(report_uuid: str, batch: list, key: bytes) -> int:
-    """Encrypt a batch of (file_row, path) into report blobs. Returns count."""
+def _encrypt_and_remove(report_uuid: str, batch: list, key: bytes) -> int:
+    """Encrypt (file_row, path) pairs into report blobs, deleting each plaintext.
+
+    The plaintext is unlinked only AFTER its blob is committed, so a crash
+    mid-round can never lose a file: at worst it stays on disk and is picked up
+    again. Taking the file offline is the point of preparing a report — while a
+    round is open the material must not be publicly reachable.
+    """
     encrypted = 0
     for f, fp in batch:
         try:
@@ -124,8 +122,63 @@ def _encrypt_batch(report_uuid: str, batch: list, key: bytes) -> int:
             ciphertext=ct,
             plaintext_sha256=crypto.sha256_hex(data),
         )
+        try:
+            fp.unlink()
+        except Exception:
+            logger.warning("failed to remove plaintext %s", fp, exc_info=True)
         encrypted += 1
     return encrypted
+
+
+def restore_report_files(report_uuid: str, p1: str) -> str | None:
+    """Decrypt a report's blobs back onto disk. Returns an error string, or None.
+
+    The inverse of preparing: cancelling a round means the files were fine, so
+    they go back where they were. Verifies P1 against every blob's stored hash
+    BEFORE writing anything — a wrong key must not scatter garbage into the
+    upload directory.
+    """
+    updir = upload_dir()
+    if updir is None:
+        return "no upload path configured"
+    key = crypto.derive_key(p1)
+    plaintexts: list[tuple[Path, bytes]] = []
+    for b in abuse.report_blobs(report_uuid):
+        try:
+            data = crypto.decrypt_file(bytes(b["nonce"]), bytes(b["ciphertext"]), key)
+        except Exception:
+            return "image key (P1) incorrect"
+        if crypto.sha256_hex(data) != b["plaintext_sha256"]:
+            return "image key (P1) incorrect"
+        plaintexts.append((updir / b["saved_filename"], data))
+    for fp, data in plaintexts:
+        try:
+            fp.write_bytes(data)
+        except Exception:
+            logger.warning("failed to restore %s", fp, exc_info=True)
+    return None
+
+
+def delete_user_files(user_id: int) -> int:
+    """Delete every on-disk file of a user. Returns how many were removed.
+
+    Banning is the end of the line: nothing of theirs stays publicly reachable.
+    Encrypted blobs of an already-filed report are untouched — those live in the
+    DB and are the evidence.
+    """
+    updir = upload_dir()
+    if updir is None:
+        return 0
+    removed = 0
+    for f in abuse.files_for_user(user_id):
+        fp = updir / f["saved_filename"]
+        try:
+            if fp.is_file():
+                fp.unlink()
+                removed += 1
+        except Exception:
+            logger.warning("failed to delete %s on ban", fp, exc_info=True)
+    return removed
 
 
 def prepare_report(user_id: int) -> PrepareResult:
@@ -133,9 +186,12 @@ def prepare_report(user_id: int) -> PrepareResult:
 
     Returns a :class:`PrepareResult`. On success it carries the new
     ``report_uuid``, the one-time image key ``p1`` (shown once, never stored),
-    and the ``encrypted`` file count. At most ``PREPARE_BATCH`` files are
-    encrypted; the rest are reported via ``remaining`` (the webview's
-    "show more" prepares them in later batches).
+    and the ``encrypted`` file count.
+
+    EVERY on-disk file of the user is encrypted into the report and its
+    plaintext removed from disk, so opening a report takes the material offline
+    for as long as the round is open. Cancelling restores the files; filing
+    keeps the reported ones encrypted and deletes the rest.
     """
     if not settings.REPORT_BASE_URL:
         return PrepareResult(error="Report server is not configured (REPORT_BASE_URL unset).")
@@ -178,45 +234,6 @@ def prepare_report(user_id: int) -> PrepareResult:
     key = crypto.derive_key(p1)
 
     abuse.create_report(report_uuid, user_id, "")
-    batch = present[:PREPARE_BATCH]
-    encrypted = _encrypt_batch(report_uuid, batch, key)
+    encrypted = _encrypt_and_remove(report_uuid, present, key)
     abuse.set_report_status(report_uuid, abuse.REPORT_READY)
-    return PrepareResult(report_uuid=report_uuid, p1=p1, encrypted=encrypted, remaining=len(present) - len(batch))
-
-
-def pending_files(report_uuid: str) -> int:
-    """How many of the report user's on-disk, non-cleared files are NOT yet blobs."""
-    rep = abuse.get_report(report_uuid)
-    if not rep:
-        return 0
-    in_report = {b["file_unique_id"] for b in abuse.report_blobs(report_uuid)}
-    present, _, _ = _present_files(rep["user_id"])
-    return sum(1 for f, _ in present if f["file_unique_id"] not in in_report)
-
-
-def extend_report(report_uuid: str, p1: str) -> PrepareResult:
-    """Encrypt the next ``PREPARE_BATCH`` not-yet-included files into the report.
-
-    ``p1`` must be the report's original image key — it is verified against an
-    existing blob's hash before anything is encrypted, so a typo can't split the
-    report across two keys.
-    """
-    rep = abuse.get_report(report_uuid)
-    if not rep:
-        return PrepareResult(error="report not found")
-    key = crypto.derive_key(p1)
-    blobs = abuse.report_blobs(report_uuid)
-    if blobs:
-        probe = blobs[0]
-        try:
-            data = crypto.decrypt_file(bytes(probe["nonce"]), bytes(probe["ciphertext"]), key)
-        except Exception:
-            return PrepareResult(error="image key (P1) incorrect")
-        if crypto.sha256_hex(data) != probe["plaintext_sha256"]:
-            return PrepareResult(error="image key (P1) incorrect")
-    in_report = {b["file_unique_id"] for b in blobs}
-    present, _, _ = _present_files(rep["user_id"])
-    todo = [(f, fp) for f, fp in present if f["file_unique_id"] not in in_report]
-    batch = todo[:PREPARE_BATCH]
-    encrypted = _encrypt_batch(report_uuid, batch, key)
-    return PrepareResult(report_uuid=report_uuid, encrypted=encrypted, remaining=len(todo) - len(batch))
+    return PrepareResult(report_uuid=report_uuid, p1=p1, encrypted=encrypted)

--- a/reverse_image_search_bot/abuse_report/server.py
+++ b/reverse_image_search_bot/abuse_report/server.py
@@ -34,7 +34,12 @@ from aiohttp import web
 from reverse_image_search_bot import settings
 from reverse_image_search_bot.abuse_report import crypto, ncmec
 from reverse_image_search_bot.abuse_report import video as abuse_video
-from reverse_image_search_bot.abuse_report.prepare import extend_report, pending_files, prepare_report, resolve_user
+from reverse_image_search_bot.abuse_report.prepare import (
+    delete_user_files,
+    prepare_report,
+    resolve_user,
+    restore_report_files,
+)
 from reverse_image_search_bot.config import abuse
 
 logger = logging.getLogger("abuse.server")
@@ -199,7 +204,6 @@ async def api_reports_create(request: web.Request) -> web.Response:
             "user_id": user_id,
             "p1": result.p1,
             "encrypted": result.encrypted,
-            "remaining": result.remaining,
         }
     )
 
@@ -257,35 +261,6 @@ async def api_unlock(request: web.Request) -> web.Response:
                 "language_code": user.get("language_code"),
                 "banned_at": user.get("banned_at"),
             },
-            "blobs": abuse.blob_meta(rep["report_uuid"]),
-            # On-disk, non-cleared files of this user NOT yet in the report —
-            # drives the gallery's "show more" button.
-            "pending": pending_files(rep["report_uuid"]),
-        }
-    )
-
-
-async def api_extend(request: web.Request) -> web.Response:
-    """Prepare the next batch of the user's files into this report ("show more").
-
-    Requires the report's image key (P1) so the new blobs share the existing
-    encryption key. Returns the refreshed blob list + how many are still pending.
-    """
-    _require_admin(request)
-    rep = _report_or_404(request.match_info["uuid"])
-    _require_page_secret(request, rep)
-    payload = await request.json()
-    p1 = payload.get("image_key", "")
-    if not p1:
-        raise web.HTTPBadRequest(text="image_key (P1) required")
-    result = await asyncio.to_thread(extend_report, rep["report_uuid"], p1)
-    if not result.ok:
-        raise web.HTTPBadRequest(text=result.error or "could not extend report")
-    return web.json_response(
-        {
-            "ok": True,
-            "encrypted": result.encrypted,
-            "remaining": result.remaining,
             "blobs": abuse.blob_meta(rep["report_uuid"]),
         }
     )
@@ -663,9 +638,10 @@ async def _run_submit(request: web.Request, rep: dict, p1: str) -> None:
 async def api_cancel(request: web.Request) -> web.Response:
     """Cancel the whole round (nothing filed with NCMEC).
 
-    Cancelling means the user did nothing wrong, so we KEEP the user's original
-    files on disk and the filename->user (files table) relation untouched. Only
-    the report's encrypted blobs + the report row's status are affected.
+    Cancelling means the user did nothing wrong, so every file taken offline when
+    the report was prepared is DECRYPTED BACK ONTO DISK — requiring P1, since the
+    plaintext only exists inside the blobs now. The filename->user (files table)
+    relation is untouched; only the encrypted blobs and the report status change.
 
     Optional ``clear_files`` in the JSON body additionally marks every file in
     the round as cleared (not problematic) — excluded from future reports.
@@ -673,10 +649,19 @@ async def api_cancel(request: web.Request) -> web.Response:
     _require_admin(request)
     rep = _report_or_404(request.match_info["uuid"])
     _require_page_secret(request, rep)
-    clear_files = False
+    payload = {}
     with contextlib.suppress(Exception):
-        # `is True` (not truthiness) so a missing/odd body can never clear files.
-        clear_files = (await request.json()).get("clear_files") is True
+        payload = await request.json()
+    p1 = payload.get("image_key", "")
+    if not p1:
+        raise web.HTTPBadRequest(text="image_key (P1) required to restore the files")
+    # Restore BEFORE purging the blobs — they are the only copy of the plaintext.
+    # A wrong key aborts without writing anything, so the files stay recoverable.
+    err = await asyncio.to_thread(restore_report_files, rep["report_uuid"], p1)
+    if err:
+        raise web.HTTPBadRequest(text=err)
+    # `is True` (not truthiness) so a missing/odd body can never clear files.
+    clear_files = payload.get("clear_files") is True
     if clear_files:
         abuse.set_files_cleared([b["file_unique_id"] for b in abuse.report_blobs(rep["report_uuid"])])
     abuse.set_report_status(rep["report_uuid"], abuse.REPORT_CANCELLED)
@@ -709,11 +694,15 @@ def _ban_reported_user(bot_data, user_id: int) -> None:
     restored on the next startup sync); appending to ``bot_data['banned_users']``
     is what the live search handler actually checks. ``bot_data`` may be None in
     tests / when the server runs bot-less — the DB write still happens.
+
+    A ban also deletes everything the user still has on disk (anything uploaded
+    after this round was prepared): banned means nothing of theirs stays served.
     """
     try:
         abuse.set_banned(user_id, True)
     except Exception:
         logger.warning("failed to set DB ban for reported user %s", user_id, exc_info=True)
+    delete_user_files(user_id)
     if bot_data is None:
         return
     try:
@@ -725,29 +714,21 @@ def _ban_reported_user(bot_data, user_id: int) -> None:
 
 
 def _cleanup_after_finish(rep: dict) -> None:
-    """On finish: delete reported plaintext from disk + drop non-reported blobs.
+    """On finish: keep the reported blobs, drop everything else.
 
     Retention rules:
-    - The REPORTED (selected) files: their plaintext is deleted from disk, but
-      their encrypted ``report_blobs`` are KEPT and stay linked to the filed
-      report, so the material remains available for further inspection or a
-      report to local law enforcement.
-    - The NON-reported (unselected) files: the admin decided they are not part of
-      the report, so their encrypted blobs are purged from the DB. Their
-      plaintext on disk is left untouched (nothing was filed about them).
+    - The REPORTED (selected) files: their encrypted ``report_blobs`` are KEPT
+      and stay linked to the filed report, so the material remains available for
+      further inspection or a report to local law enforcement. Their plaintext
+      already left the disk when the report was prepared.
+    - Everything else in the round: purged. The unselected blobs are deleted
+      from the DB along with any encrypted video ciphertext on disk — filing
+      means the user is banned, and a banned user's material is not kept.
 
     The user row, ban, and report record are always kept.
     """
-    reported = abuse.report_blobs(rep["report_uuid"], selected_only=True)
     upload_path = settings.UPLOADER.get("configuration", {}).get("path")
     if upload_path:
-        for b in reported:
-            try:
-                fp = Path(upload_path) / b["saved_filename"]
-                if fp.is_file():
-                    fp.unlink()
-            except Exception:
-                logger.warning("failed to delete plaintext %s", b["saved_filename"], exc_info=True)
         # Delete encrypted video ciphertext for UNSELECTED blobs (their blobs are
         # about to be purged); reported blobs keep their encrypted video on disk.
         for b in abuse.report_blobs(rep["report_uuid"]):
@@ -784,7 +765,6 @@ def build_app(bot=None, bot_data=None) -> web.Application:
     app.router.add_get("/report/{uuid}/api/blob/{blob_id}/video", api_video)
     app.router.add_get("/report/{uuid}/api/status", api_status)
     app.router.add_post("/report/{uuid}/api/select", api_select)
-    app.router.add_post("/report/{uuid}/api/extend", api_extend)
     app.router.add_post("/report/{uuid}/api/review", api_review)
     app.router.add_post("/report/{uuid}/api/submit", api_submit)
     app.router.add_post("/report/{uuid}/api/cancel", api_cancel)

--- a/reverse_image_search_bot/abuse_report/server.py
+++ b/reverse_image_search_bot/abuse_report/server.py
@@ -35,8 +35,10 @@ from reverse_image_search_bot import settings
 from reverse_image_search_bot.abuse_report import crypto, ncmec
 from reverse_image_search_bot.abuse_report import video as abuse_video
 from reverse_image_search_bot.abuse_report.prepare import (
+    blob_ciphertext,
     delete_user_files,
     prepare_report,
+    purge_cipher_dir,
     resolve_user,
     restore_report_files,
 )
@@ -45,6 +47,9 @@ from reverse_image_search_bot.config import abuse
 logger = logging.getLogger("abuse.server")
 
 _STATIC = Path(__file__).parent / "static"
+# Live prepare progress ("done/total"), keyed by the user id being prepared.
+# Single process, so an in-memory dict is enough (same pattern as _submit_progress).
+_prepare_progress: dict[int, str] = {}
 # "NR" = selected/reported but Not Rated — no NCMEC industryClassification is
 # sent (that field is optional). Everything else must be a real A1-B2 code.
 _VALID_CLASSES = {"A1", "A2", "B1", "B2", "NR"}
@@ -164,6 +169,27 @@ async def api_reports_stats(request: web.Request) -> web.Response:
     return web.json_response({"records": abuse.filed_report_stats()})
 
 
+async def api_prepare_progress(request: web.Request) -> web.Response:
+    """Live encryption progress for an in-flight create ("done/total").
+
+    The create request itself blocks until the whole round is encrypted, so the
+    console polls this alongside it to show movement on a big user/group.
+
+    Keyed by the same ``target`` token the create was given — the client has no
+    user id until the create returns, so it can't poll by id.
+    """
+    _require_admin(request)
+    if not crypto.verify_global_page_password(request.headers.get("X-Page-Secret", ""), settings.REPORT_PAGE_PASSWORD):
+        raise web.HTTPForbidden(text="page password incorrect")
+    target = (request.query.get("target") or "").strip()
+    if not target:
+        raise web.HTTPBadRequest(text="target required")
+    user_id = resolve_user(target)
+    if user_id is None:
+        return web.json_response({"progress": None})
+    return web.json_response({"progress": _prepare_progress.get(user_id)})
+
+
 async def api_reports_create(request: web.Request) -> web.Response:
     """Create a new report from a target token (user id, @username, or filename).
 
@@ -184,7 +210,16 @@ async def api_reports_create(request: web.Request) -> web.Response:
 
     # prepare_report encrypts up to a batch of files (PBKDF2 + AES) — run it off
     # the event loop so a big report can't stall the webhook/report server.
-    result = await asyncio.to_thread(prepare_report, user_id)
+    # Progress is published under the target user id so the console can poll it
+    # while this request is still in flight.
+    def note(done: int, total: int) -> None:
+        _prepare_progress[user_id] = f"{done}/{total}"
+
+    _prepare_progress[user_id] = "0/?"
+    try:
+        result = await asyncio.to_thread(prepare_report, user_id, note)
+    finally:
+        _prepare_progress.pop(user_id, None)
     if not result.ok:
         # An existing active report is a 409 carrying its uuid so the UI can jump to it.
         if result.existing_uuid:
@@ -275,7 +310,10 @@ async def api_blob(request: web.Request) -> web.Response:
     row = abuse.get_blob_cipher(rep["report_uuid"], blob_id)
     if not row:
         raise web.HTTPNotFound(text="blob not found")
-    body = bytes(row["nonce"]) + bytes(row["ciphertext"])
+    ct = blob_ciphertext(row)
+    if ct is None:
+        raise web.HTTPNotFound(text="ciphertext missing on disk")
+    body = bytes(row["nonce"]) + ct
     return web.Response(body=body, content_type="application/octet-stream")
 
 
@@ -444,8 +482,11 @@ async def _gather_selected_files(
     base = settings.UPLOADER.get("configuration", {}).get("path")
     for idx, b in enumerate(selected, 1):
         _note(f"decrypting {idx}/{len(selected)}")
+        cipher = blob_ciphertext(b)
+        if cipher is None:
+            raise web.HTTPBadRequest(text=f"ciphertext missing on disk for {b['saved_filename']}")
         try:
-            plaintext = crypto.decrypt_file(bytes(b["nonce"]), bytes(b["ciphertext"]), key)
+            plaintext = crypto.decrypt_file(bytes(b["nonce"]), cipher, key)
         except Exception as dec_err:
             raise web.HTTPBadRequest(text="image key (P1) incorrect — decryption failed") from dec_err
         if crypto.sha256_hex(plaintext) != b["plaintext_sha256"]:
@@ -678,6 +719,7 @@ async def api_cancel(request: web.Request) -> web.Response:
                 except Exception:
                     logger.warning("failed to delete video on cancel %s", b["video_path"], exc_info=True)
     abuse.purge_report_blobs(rep["report_uuid"])
+    purge_cipher_dir(rep["report_uuid"])
     return web.json_response({"ok": True, "status": abuse.REPORT_CANCELLED})
 
 
@@ -714,20 +756,32 @@ def _ban_reported_user(bot_data, user_id: int) -> None:
 
 
 def _cleanup_after_finish(rep: dict) -> None:
-    """On finish: keep the reported blobs, drop everything else.
+    """On finish: move the reported ciphertext INTO the DB, drop everything else.
 
     Retention rules:
-    - The REPORTED (selected) files: their encrypted ``report_blobs`` are KEPT
-      and stay linked to the filed report, so the material remains available for
-      further inspection or a report to local law enforcement. Their plaintext
-      already left the disk when the report was prepared.
+    - The REPORTED (selected) files: filing is what earns a place in the DB, so
+      their encrypted bytes are read off disk and written into the blob row.
+      They stay linked to the filed report, available for further inspection or
+      a report to local law enforcement, and no longer depend on a file that the
+      ban sweep below would delete. Their plaintext left the disk at prepare time.
     - Everything else in the round: purged. The unselected blobs are deleted
-      from the DB along with any encrypted video ciphertext on disk — filing
-      means the user is banned, and a banned user's material is not kept.
+      from the DB, and the report's whole on-disk ciphertext directory goes with
+      them — filing means the user is banned, and a banned user's material is
+      not kept. Reported VIDEOS keep their encrypted file on disk (they are far
+      too large for SQLite; that is the pre-existing design).
 
     The user row, ban, and report record are always kept.
     """
     upload_path = settings.UPLOADER.get("configuration", {}).get("path")
+    # Reported images: disk ciphertext -> DB. Do this BEFORE any purging.
+    for b in abuse.report_blobs(rep["report_uuid"], selected_only=True):
+        if not b.get("cipher_path"):
+            continue
+        cipher = blob_ciphertext(b)
+        if cipher is None:
+            logger.warning("ciphertext missing for filed blob %s — cannot persist", b["id"])
+            continue
+        abuse.set_blob_ciphertext(b["id"], cipher)
     if upload_path:
         # Delete encrypted video ciphertext for UNSELECTED blobs (their blobs are
         # about to be purged); reported blobs keep their encrypted video on disk.
@@ -741,6 +795,8 @@ def _cleanup_after_finish(rep: dict) -> None:
                     logger.warning("failed to delete unselected video %s", b["video_path"], exc_info=True)
     # Drop only the non-reported blobs; keep the reported ones linked to the report.
     abuse.purge_unselected_blobs(rep["report_uuid"])
+    # Every image ciphertext is either in the DB now (reported) or unwanted.
+    purge_cipher_dir(rep["report_uuid"])
 
 
 async def healthz(request: web.Request) -> web.Response:
@@ -757,6 +813,7 @@ def build_app(bot=None, bot_data=None) -> web.Application:
     app.router.add_get("/report/console", reports_index)
     app.router.add_get("/report/console/api/list", api_reports_list)
     app.router.add_get("/report/console/api/stats", api_reports_stats)
+    app.router.add_get("/report/console/api/prepare_progress", api_prepare_progress)
     app.router.add_post("/report/console/api/create", api_reports_create)
     app.router.add_get("/report/{uuid}", index)
     app.router.add_post("/report/{uuid}/api/unlock", api_unlock)

--- a/reverse_image_search_bot/abuse_report/static/report.html
+++ b/reverse_image_search_bot/abuse_report/static/report.html
@@ -173,10 +173,6 @@
         <span class="muted"><span id="save-state" style="color:#7fd6a2;margin-right:8px"></span><span id="sel-count">0 selected</span></span>
       </div>
       <div class="gallery" id="gallery"></div>
-      <div class="row" style="margin-top:10px">
-        <button id="more-btn" class="secondary hidden">Show more</button>
-      </div>
-      <div class="muted" id="more-err" style="color:#f08a8a;margin-top:6px"></div>
     </div>
 
     <div class="card" id="action-card">
@@ -219,7 +215,7 @@
 <dialog id="cancel-dlg">
   <div class="dlg-body">
     <h2>Cancel this report?</h2>
-    <div class="muted" style="margin-bottom:12px">The encrypted blobs and this report are discarded, but the user's original files and records are KEPT.</div>
+    <div class="muted" style="margin-bottom:12px">The files are decrypted back onto disk and the encrypted blobs discarded. Needs the image key (P1) — it is the only copy.</div>
     <label style="display:flex;gap:8px;align-items:flex-start;font-size:14px;color:#e8e8ea;margin-bottom:14px;cursor:pointer">
       <input type="checkbox" id="cancel-clear" style="margin-top:3px">
       <span>Mark all images in this round as <b>cleared</b>.</span>
@@ -358,7 +354,6 @@ function renderGallery() {
     g.appendChild(d);
   }
   updateSelCount();
-  updateMoreBtn();
 }
 
 $("decrypt-btn").onclick = async () => {
@@ -443,45 +438,6 @@ function wireCls(id) {
 function updateSelCount() {
   $("sel-count").textContent = Object.keys(sel).length + " selected";
 }
-
-// --- "Show more": prepare the next batch of pending files into this report ---
-function updateMoreBtn() {
-  const btn = $("more-btn");
-  const pending = META.pending || 0;
-  const active = !["filed", "cancelled"].includes(META.status);
-  btn.classList.toggle("hidden", !(pending > 0 && active));
-  if (pending > 0) btn.textContent = `Show more (${pending} pending)`;
-}
-
-$("more-btn").onclick = async () => {
-  $("more-err").textContent = "";
-  if (!P1KEY) { $("more-err").textContent = "Image key is needed to load more."; return; }
-  const btn = $("more-btn"); btn.disabled = true; btn.textContent = "Preparing…";
-  try {
-    const r = await api("/api/extend", {
-      method: "POST", headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ image_key: $("p1").value }),
-    });
-    const j = await r.json();
-    const known = new Set(META.blobs.map(b => b.id));
-    const added = j.blobs.filter(b => !known.has(b.id));
-    META.blobs = j.blobs;
-    META.pending = j.remaining;
-    const g = $("gallery");
-    for (const b of added) {
-      const d = document.createElement("div");
-      d.className = "thumb"; d.dataset.id = b.id;
-      d.innerHTML = `<div class="fname">${blobLabel(b)}</div><div class="lock">🔒</div>`;
-      g.appendChild(d);
-      await decryptThumb(b);
-    }
-  } catch (e) {
-    $("more-err").textContent = "" + e.message;
-  } finally {
-    btn.disabled = false;
-    updateMoreBtn();
-  }
-};
 
 // --- viewer dialog (image + optional source video) ---------------------------
 const viewer = $("viewer");
@@ -872,16 +828,18 @@ $("cancel-btn").onclick = () => { $("cancel-clear").checked = false; cancelDlg.s
 $("cancel-back-btn").onclick = () => cancelDlg.close();
 $("cancel-confirm-btn").onclick = async () => {
   const clearFiles = $("cancel-clear").checked;
+  // Cancelling restores the plaintext from the blobs, so it needs P1.
+  if (!$("p1").value) { cancelDlg.close(); $("action-err").textContent = "Enter the image key (P1) first — cancelling restores the files."; return; }
   try {
     await api("/api/cancel", {
       method: "POST", headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ clear_files: clearFiles }),
+      body: JSON.stringify({ clear_files: clearFiles, image_key: $("p1").value }),
     });
     cancelDlg.close();
     applyFinalState("cancelled");
     window.scrollTo({ top: 0, behavior: "smooth" });
     showNotice("Report cancelled",
-      "The report was cancelled. The encrypted blobs were discarded; the user's original files and records are kept."
+      "The report was cancelled. The files were decrypted back onto disk and the encrypted blobs discarded."
       + (clearFiles ? " All images in this round were marked cleared." : ""));
   } catch (e) { cancelDlg.close(); $("action-err").textContent = "" + e.message; }
 };
@@ -902,12 +860,11 @@ function applyFinalState(status, reportId) {
   b.className = "status " + status;
   b.textContent = status === "filed"
     ? "✓ Filed with NCMEC — report id " + (reportId || META.ncmec_report_id || "")
-    : "Cancelled — user's files kept";
+    : "Cancelled — files restored to disk";
   b.classList.remove("hidden");
   // Keep the decrypt card + gallery available after filing so the reported
   // images can still be inspected; only the submit/cancel actions are removed.
   $("action-card").classList.add("hidden");
-  updateMoreBtn();
   if (status === "filed") {
     applyFiledLayout();
     window.scrollTo({ top: 0, behavior: "smooth" });

--- a/reverse_image_search_bot/abuse_report/static/reports.html
+++ b/reverse_image_search_bot/abuse_report/static/reports.html
@@ -107,6 +107,7 @@
           <button id="create-btn">Create</button>
         </div>
         <div class="err" id="create-err"></div>
+        <div class="muted hidden" id="create-progress" style="margin-top:8px"></div>
         <div id="create-ok" class="hidden" style="margin-top:10px"></div>
       </div>
 
@@ -265,6 +266,18 @@ $("create-btn").onclick = async () => {
   $("create-ok").classList.add("hidden");
   const target = $("target").value.trim();
   if (!target) { $("create-err").textContent = "Enter a user id, @username, or filename."; return; }
+  // The create request blocks until every file is encrypted, which is slow for
+  // a big user/group — poll a side channel so the admin sees it move.
+  const btn = $("create-btn"); btn.disabled = true;
+  const prog = $("create-progress");
+  prog.classList.remove("hidden");
+  prog.textContent = "⏳ preparing…";
+  const poll = setInterval(async () => {
+    try {
+      const p = await (await api("/api/prepare_progress?target=" + encodeURIComponent(target))).json();
+      if (p.progress) prog.textContent = "⏳ encrypting " + p.progress + "…";
+    } catch (e) { /* transient — keep polling */ }
+  }, 1000);
   try {
     const r = await api("/api/create", {
       method: "POST", headers: { "Content-Type": "application/json" },
@@ -291,7 +304,13 @@ $("create-btn").onclick = async () => {
     $("goto-new").onclick = () => openReport(j.uuid);
     $("target").value = "";
     loadList().catch(() => {});
-  } catch (e) { $("create-err").textContent = "" + e.message; }
+  } catch (e) {
+    $("create-err").textContent = "" + e.message;
+  } finally {
+    clearInterval(poll);
+    prog.classList.add("hidden");
+    btn.disabled = false;
+  }
 };
 
 function escapeHtml(s) {

--- a/reverse_image_search_bot/bot.py
+++ b/reverse_image_search_bot/bot.py
@@ -29,6 +29,7 @@ from telegram.ext import (
 )
 
 from . import metrics, settings
+from .abuse_report.prepare import delete_user_files
 from .commands import (
     callback_query_handler,
     file_handler,
@@ -160,7 +161,10 @@ async def ban_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     else:
         banned.append(user_id)
         abuse.set_banned(user_id, True)
-        text = f"banned user {user_id=}"
+        # Banning removes everything they still have on disk. Encrypted blobs of
+        # a filed report are untouched — those are the evidence, not served files.
+        removed = delete_user_files(user_id)
+        text = f"banned user {user_id=}, deleted {removed} file(s)"
     await update.message.reply_text(text)
 
 

--- a/reverse_image_search_bot/commands/report.py
+++ b/reverse_image_search_bot/commands/report.py
@@ -27,6 +27,36 @@ from reverse_image_search_bot.config import abuse
 
 logger = logging.getLogger("abuse.commands")
 
+# Don't edit the progress message more often than this (Telegram rate limits
+# edits, and a 500-file round would otherwise fire 500 edits).
+PROGRESS_EVERY = 10
+
+
+def _progress_pump(message, prefix: str):
+    """Build a (done, total) callback that live-edits ``message``.
+
+    ``prepare_report`` runs in a worker thread (asyncio.to_thread), so the
+    callback cannot await — it schedules the edit back onto the running loop
+    with ``run_coroutine_threadsafe`` and never blocks the encryption.
+    """
+    loop = asyncio.get_running_loop()
+
+    def on_progress(done: int, total: int) -> None:
+        if done != total and done % PROGRESS_EVERY:
+            return
+        text = f"{prefix} encrypting {done}/{total}…"
+        with contextlib.suppress(Exception):
+            asyncio.run_coroutine_threadsafe(_safe_edit(message, text), loop)
+
+    return on_progress
+
+
+async def _safe_edit(message, text: str) -> None:
+    """Edit a status message, ignoring rate limits / identical-content errors."""
+    with contextlib.suppress(Exception):
+        await message.edit_text(text)
+
+
 # Cloudflare CSAM reports list our public file URLs like
 #   https://ris.naa.gg/f/AQADsAxrG35d6EZ9.jpg
 # (often defanged: hxxps://ris.naa[.]gg/f/…). The /f/<file> path segment is never
@@ -112,7 +142,10 @@ async def report_users(
     for uid in uids:
         user = abuse.get_user(uid) or {}
         uname = f"@{user['username']}" if user.get("username") else "—"
-        result = await asyncio.to_thread(prepare_report, uid)
+        # Plain text — _safe_edit uses edit_text (no parse_mode).
+        prefix = f"⏳ user {uid} ({len(rows) + 1}/{len(uids)}) —" if len(uids) > 1 else "⏳"
+        on_progress = _progress_pump(status_msg, prefix) if status_msg else None
+        result = await asyncio.to_thread(prepare_report, uid, on_progress)
         if result.ok:
             rows.append(
                 {
@@ -235,7 +268,8 @@ async def start_report(update: Update, context: ContextTypes.DEFAULT_TYPE, user_
     status_msg = None
     with contextlib.suppress(Exception):
         status_msg = await update.message.reply_text("⏳ Preparing report…")
-    result = await asyncio.to_thread(prepare_report, user_id)
+    on_progress = _progress_pump(status_msg, "⏳") if status_msg else None
+    result = await asyncio.to_thread(prepare_report, user_id, on_progress)
     if status_msg is not None:
         with contextlib.suppress(Exception):
             await status_msg.delete()

--- a/reverse_image_search_bot/commands/report.py
+++ b/reverse_image_search_bot/commands/report.py
@@ -114,13 +114,12 @@ async def report_users(
         uname = f"@{user['username']}" if user.get("username") else "—"
         result = await asyncio.to_thread(prepare_report, uid)
         if result.ok:
-            more = f" (+{result.remaining} more via Show more)" if result.remaining else ""
             rows.append(
                 {
                     "icon": "🆕",
                     "user_id": uid,
                     "username": uname,
-                    "detail": f"P1 <code>{html.escape(result.p1 or '')}</code>{more}",
+                    "detail": f"P1 <code>{html.escape(result.p1 or '')}</code> · {result.encrypted} file(s) offline",
                     "uuid": result.report_uuid,
                 }
             )
@@ -269,19 +268,14 @@ async def start_report(update: Update, context: ContextTypes.DEFAULT_TYPE, user_
     )
     await update.message.reply_html(
         f"<b>Report prepared</b> for user <code>{user_id}</code> ({html.escape(uname)})\n"
-        f"Encrypted <b>{result.encrypted}</b> file(s)."
-        + (
-            f" <b>{result.remaining}</b> more can be added via the page's Show more button.\n\n"
-            if result.remaining
-            else "\n\n"
-        )
+        f"Encrypted <b>{result.encrypted}</b> file(s) and took them offline.\n\n"
         + f"<b>Image key (P1):</b> <code>{html.escape(result.p1 or '')}</code>\n\n"
         f"{launch}\n\n"
         f"<i>Use the global page password to open the report, then P1 to decrypt "
-        f"the images. P1 is not stored — if you lose it the thumbnails can't be "
-        f"shown (the files still exist on disk until you file/cancel). On filing, "
-        f"the plaintext files are deleted from disk but the encrypted copies stay "
-        f"in the DB, linked to the report, for further inspection.</i>",
+        f"the images. The files are no longer on disk — the encrypted blobs are "
+        f"the only copy, so P1 is NOT recoverable and losing it loses the files. "
+        f"Cancelling restores them to disk; filing keeps the reported ones "
+        f"encrypted in the DB, bans the user, and deletes the rest.</i>",
         disable_web_page_preview=True,
     )
 

--- a/reverse_image_search_bot/config/abuse.py
+++ b/reverse_image_search_bot/config/abuse.py
@@ -218,6 +218,12 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         )
     """)
     conn.execute("CREATE INDEX IF NOT EXISTS idx_blobs_report ON report_blobs(report_uuid)")
+    # Where a blob's image ciphertext lives while the report is open: on disk,
+    # under the upload PVC (`cipher_path`), NOT in SQLite. Only the files that
+    # actually get FILED are moved into the `ciphertext` column on finish. The
+    # column stays NOT NULL (old DBs can't drop it) — an empty blob plus a set
+    # `cipher_path` means "on disk"; see prepare.blob_ciphertext().
+    _add_column_if_missing(conn, "report_blobs", "cipher_path", "TEXT")
     # One blob per file per report. A raced extend (e.g. client retry during a
     # locked-DB episode) used to insert duplicates; drop any existing ones (keep
     # the lowest id) so the unique index can be created on old DBs. Once that
@@ -602,10 +608,15 @@ def add_report_blob(
     file_unique_id: str,
     saved_filename: str,
     nonce: bytes,
-    ciphertext: bytes,
     plaintext_sha256: str,
+    ciphertext: bytes = b"",
+    cipher_path: str | None = None,
 ) -> int:
     """Insert an image blob. Returns the blob id (existing one if already present).
+
+    Pass ``cipher_path`` (relative to the upload dir) for the normal case: the
+    ciphertext sits on disk and only ``nonce`` + hash + path go in the DB.
+    ``ciphertext`` is for blobs whose bytes live in the DB — i.e. filed ones.
 
     ``INSERT OR IGNORE`` + the unique (report_uuid, file_unique_id) index make
     this idempotent — a raced/retried extend can't create duplicate blobs.
@@ -615,10 +626,20 @@ def add_report_blob(
         cur = conn.execute(
             """
             INSERT OR IGNORE INTO report_blobs
-                (report_uuid, file_unique_id, saved_filename, nonce, ciphertext, plaintext_sha256, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+                (report_uuid, file_unique_id, saved_filename, nonce, ciphertext, cipher_path,
+                 plaintext_sha256, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (report_uuid, file_unique_id, saved_filename, nonce, ciphertext, plaintext_sha256, _now()),
+            (
+                report_uuid,
+                file_unique_id,
+                saved_filename,
+                nonce,
+                ciphertext,
+                cipher_path,
+                plaintext_sha256,
+                _now(),
+            ),
         )
         if cur.rowcount == 0:  # already there — return the existing blob's id
             row = conn.execute(
@@ -627,6 +648,21 @@ def add_report_blob(
             ).fetchone()
             return int(row["id"]) if row else 0
     return int(cur.lastrowid or 0)
+
+
+def set_blob_ciphertext(blob_id: int, ciphertext: bytes) -> None:
+    """Move a blob's ciphertext INTO the DB and forget its on-disk path.
+
+    Called on filing: a reported file's encrypted bytes become part of the
+    permanent record, so they stop depending on a file that later cleanup (or a
+    ban) would delete.
+    """
+    conn = _get_conn()
+    with conn:
+        conn.execute(
+            "UPDATE report_blobs SET ciphertext = ?, cipher_path = NULL WHERE id = ?",
+            (ciphertext, blob_id),
+        )
 
 
 def set_blob_video(
@@ -731,7 +767,7 @@ def get_blob_cipher(report_uuid: str, blob_id: int) -> dict | None:
     """Nonce + ciphertext for one blob (for the browser to decrypt)."""
     conn = _get_conn()
     row = conn.execute(
-        "SELECT id, nonce, ciphertext FROM report_blobs WHERE report_uuid = ? AND id = ?",
+        "SELECT id, nonce, ciphertext, cipher_path FROM report_blobs WHERE report_uuid = ? AND id = ?",
         (report_uuid, blob_id),
     ).fetchone()
     return dict(row) if row else None
@@ -786,6 +822,13 @@ def active_report_for_user(user_id: int) -> dict | None:
         (user_id, REPORT_PREPARING, REPORT_READY, REPORT_REVIEW, REPORT_SUBMITTING),
     ).fetchone()
     return dict(row) if row else None
+
+
+def reports_for_user(user_id: int) -> list[dict]:
+    """Every report row for a user, newest first."""
+    conn = _get_conn()
+    rows = conn.execute("SELECT * FROM reports WHERE user_id = ? ORDER BY created_at DESC", (user_id,)).fetchall()
+    return [dict(r) for r in rows]
 
 
 def all_reports() -> list[dict]:

--- a/tests/test_abuse_prepare.py
+++ b/tests/test_abuse_prepare.py
@@ -47,6 +47,17 @@ def env(abuse, tmp_path, monkeypatch):
     return abuse, updir, mkfiles
 
 
+def plaintexts(updir):
+    """Uploaded plaintext files still on disk (ignores report_files/ ciphertext)."""
+    return sorted(p.name for p in updir.iterdir() if p.is_file())
+
+
+def ciphertexts(updir, report_uuid):
+    """Encrypted blobs on disk for a report."""
+    d = updir / "report_files" / report_uuid
+    return sorted(p.name for p in d.iterdir()) if d.is_dir() else []
+
+
 def test_prepare_encrypts_every_file_and_takes_them_offline(env):
     from reverse_image_search_bot.abuse_report import crypto, prepare
 
@@ -57,11 +68,16 @@ def test_prepare_encrypts_every_file_and_takes_them_offline(env):
     assert result.encrypted == 30
     assert len(abuse.blob_meta(result.report_uuid)) == 30
     # No cap: every plaintext is gone from disk while the round is open.
-    assert list(updir.iterdir()) == []
-    # And the blobs really hold the plaintext, under P1.
+    assert plaintexts(updir) == []
+    # The ciphertext is on DISK, not in the DB — only filed files enter SQLite.
+    assert len(ciphertexts(updir, result.report_uuid)) == 30
     key = crypto.derive_key(result.p1 or "")
     b = abuse.report_blobs(result.report_uuid)[0]
-    plain = crypto.decrypt_file(bytes(b["nonce"]), bytes(b["ciphertext"]), key)
+    assert bytes(b["ciphertext"]) == b""
+    assert b["cipher_path"].startswith(f"report_files/{result.report_uuid}/")
+    cipher = prepare.blob_ciphertext(b)
+    assert cipher is not None
+    plain = crypto.decrypt_file(bytes(b["nonce"]), cipher, key)
     assert crypto.sha256_hex(plain) == b["plaintext_sha256"]
 
 
@@ -86,7 +102,7 @@ def test_restore_with_wrong_key_writes_nothing(env):
     result = prepare.prepare_report(1)
     err = prepare.restore_report_files(result.report_uuid or "", "totally-wrong-key")
     assert "P1" in (err or "")
-    assert list(updir.iterdir()) == []  # nothing scattered into the upload dir
+    assert plaintexts(updir) == []  # nothing scattered into the upload dir
 
 
 def test_delete_user_files_removes_everything_on_disk(env):
@@ -98,6 +114,49 @@ def test_delete_user_files_removes_everything_on_disk(env):
     assert prepare.delete_user_files(1) == 3
     assert not (updir / "F0.jpg").exists()
     assert (updir / "OTHER0.jpg").exists()  # other users untouched
+
+
+def test_prepare_reports_progress(env):
+    from reverse_image_search_bot.abuse_report import prepare
+
+    _abuse, _, mkfiles = env
+    mkfiles(1, 5)
+    seen = []
+    result = prepare.prepare_report(1, lambda done, total: seen.append((done, total)))
+    assert result.ok
+    assert seen == [(1, 5), (2, 5), (3, 5), (4, 5), (5, 5)]
+
+
+def test_ban_deletes_encrypted_leftovers_of_an_open_report(env):
+    """Ban with a round still open: the ciphertext goes too, blobs and all."""
+    from reverse_image_search_bot.abuse_report import prepare
+
+    abuse, updir, mkfiles = env
+    mkfiles(1, 3)
+    result = prepare.prepare_report(1)
+    assert len(ciphertexts(updir, result.report_uuid)) == 3
+
+    prepare.delete_user_files(1)
+    assert ciphertexts(updir, result.report_uuid) == []
+    assert abuse.report_blobs(result.report_uuid) == []
+
+
+def test_ban_keeps_a_filed_report_intact(env):
+    """A filed report's blobs live in the DB and must survive the ban sweep."""
+    from reverse_image_search_bot.abuse_report import prepare
+
+    abuse, _, mkfiles = env
+    mkfiles(1, 2)
+    result = prepare.prepare_report(1)
+    # Simulate filing: bytes into the DB, then the round is marked filed.
+    for b in abuse.report_blobs(result.report_uuid):
+        abuse.set_blob_ciphertext(b["id"], prepare.blob_ciphertext(b) or b"")
+    abuse.mark_report_filed(result.report_uuid)
+
+    prepare.delete_user_files(1)
+    kept = abuse.report_blobs(result.report_uuid)
+    assert len(kept) == 2
+    assert all(bytes(b["ciphertext"]) for b in kept)
 
 
 def test_cleared_files_excluded_from_prepare(env):
@@ -183,7 +242,7 @@ async def test_cancel_restores_files_and_rejects_wrong_key(env, monkeypatch):
     abuse, updir, mkfiles = env
     mkfiles(1, 2)
     result = prepare.prepare_report(1)
-    assert list(updir.iterdir()) == []
+    assert plaintexts(updir) == []
 
     monkeypatch.setattr(server, "_admin_from_request", lambda req: 42)
     req = MagicMock(spec=web.Request)

--- a/tests/test_abuse_prepare.py
+++ b/tests/test_abuse_prepare.py
@@ -1,4 +1,4 @@
-"""Tests for report preparation batching + the cleared (not-problematic) state."""
+"""Tests for report preparation (take files offline) + the cleared state."""
 
 from __future__ import annotations
 
@@ -47,50 +47,57 @@ def env(abuse, tmp_path, monkeypatch):
     return abuse, updir, mkfiles
 
 
-def test_prepare_caps_at_batch_and_reports_remaining(env):
-    from reverse_image_search_bot.abuse_report import prepare
-
-    abuse, _, mkfiles = env
-    mkfiles(1, prepare.PREPARE_BATCH + 5)
-    result = prepare.prepare_report(1)
-    assert result.ok
-    assert result.encrypted == prepare.PREPARE_BATCH
-    assert result.remaining == 5
-    assert len(abuse.blob_meta(result.report_uuid)) == prepare.PREPARE_BATCH
-    assert prepare.pending_files(result.report_uuid or "") == 5
-
-
-def test_extend_adds_next_batch_with_same_key(env):
+def test_prepare_encrypts_every_file_and_takes_them_offline(env):
     from reverse_image_search_bot.abuse_report import crypto, prepare
 
-    abuse, _, mkfiles = env
-    mkfiles(1, prepare.PREPARE_BATCH + 3)
+    abuse, updir, mkfiles = env
+    mkfiles(1, 30)
     result = prepare.prepare_report(1)
-    assert result.remaining == 3
-
-    ext = prepare.extend_report(result.report_uuid or "", result.p1 or "")
-    assert ext.ok
-    assert ext.encrypted == 3
-    assert ext.remaining == 0
-    blobs = abuse.report_blobs(result.report_uuid)
-    assert len(blobs) == prepare.PREPARE_BATCH + 3
-    # New blobs decrypt with the ORIGINAL key.
+    assert result.ok
+    assert result.encrypted == 30
+    assert len(abuse.blob_meta(result.report_uuid)) == 30
+    # No cap: every plaintext is gone from disk while the round is open.
+    assert list(updir.iterdir()) == []
+    # And the blobs really hold the plaintext, under P1.
     key = crypto.derive_key(result.p1 or "")
-    last = blobs[-1]
-    plain = crypto.decrypt_file(bytes(last["nonce"]), bytes(last["ciphertext"]), key)
-    assert crypto.sha256_hex(plain) == last["plaintext_sha256"]
+    b = abuse.report_blobs(result.report_uuid)[0]
+    plain = crypto.decrypt_file(bytes(b["nonce"]), bytes(b["ciphertext"]), key)
+    assert crypto.sha256_hex(plain) == b["plaintext_sha256"]
 
 
-def test_extend_rejects_wrong_key(env):
+def test_restore_puts_files_back(env):
     from reverse_image_search_bot.abuse_report import prepare
 
-    abuse, _, mkfiles = env
-    mkfiles(1, prepare.PREPARE_BATCH + 1)
+    _abuse, updir, mkfiles = env
+    mkfiles(1, 3)
     result = prepare.prepare_report(1)
-    ext = prepare.extend_report(result.report_uuid or "", "totally-wrong-key")
-    assert not ext.ok
-    assert "P1" in (ext.error or "")
-    assert len(abuse.report_blobs(result.report_uuid)) == prepare.PREPARE_BATCH
+    assert not (updir / "F0.jpg").exists()
+
+    assert prepare.restore_report_files(result.report_uuid or "", result.p1 or "") is None
+    assert (updir / "F0.jpg").read_bytes() == b"img-F0"
+    assert (updir / "F2.jpg").read_bytes() == b"img-F2"
+
+
+def test_restore_with_wrong_key_writes_nothing(env):
+    from reverse_image_search_bot.abuse_report import prepare
+
+    _abuse, updir, mkfiles = env
+    mkfiles(1, 2)
+    result = prepare.prepare_report(1)
+    err = prepare.restore_report_files(result.report_uuid or "", "totally-wrong-key")
+    assert "P1" in (err or "")
+    assert list(updir.iterdir()) == []  # nothing scattered into the upload dir
+
+
+def test_delete_user_files_removes_everything_on_disk(env):
+    from reverse_image_search_bot.abuse_report import prepare
+
+    _abuse, updir, mkfiles = env
+    mkfiles(1, 3)
+    mkfiles(2, 1, prefix="OTHER")
+    assert prepare.delete_user_files(1) == 3
+    assert not (updir / "F0.jpg").exists()
+    assert (updir / "OTHER0.jpg").exists()  # other users untouched
 
 
 def test_cleared_files_excluded_from_prepare(env):
@@ -133,11 +140,11 @@ async def test_cancel_with_clear_files_marks_round_cleared(env, monkeypatch):
     req.query = {}
     req.match_info = {"uuid": uuid}
     req.app = {"bot": None}
-    req.json = AsyncMock(return_value={"clear_files": True})
+    req.json = AsyncMock(return_value={"clear_files": True, "image_key": result.p1})
     await server.api_cancel(req)
 
     assert abuse.get_report(uuid)["status"] == abuse.REPORT_CANCELLED
-    # Disk files kept, but both marked cleared → a re-report finds nothing.
+    # Files restored to disk, but both marked cleared → a re-report finds nothing.
     assert (updir / "F0.jpg").exists()
     again = prepare.prepare_report(1)
     assert not again.ok
@@ -160,11 +167,44 @@ async def test_cancel_without_clear_keeps_files_reportable(env, monkeypatch):
     req.query = {}
     req.match_info = {"uuid": result.report_uuid}
     req.app = {"bot": None}
-    req.json = AsyncMock(return_value={"clear_files": False})
+    req.json = AsyncMock(return_value={"clear_files": False, "image_key": result.p1})
     await server.api_cancel(req)
 
     again = prepare.prepare_report(1)
     assert again.ok  # still reportable
+
+
+@pytest.mark.asyncio
+async def test_cancel_restores_files_and_rejects_wrong_key(env, monkeypatch):
+    from unittest.mock import AsyncMock
+
+    from reverse_image_search_bot.abuse_report import prepare, server
+
+    abuse, updir, mkfiles = env
+    mkfiles(1, 2)
+    result = prepare.prepare_report(1)
+    assert list(updir.iterdir()) == []
+
+    monkeypatch.setattr(server, "_admin_from_request", lambda req: 42)
+    req = MagicMock(spec=web.Request)
+    req.headers = {"X-Page-Secret": "pw"}
+    req.query = {}
+    req.match_info = {"uuid": result.report_uuid}
+    req.app = {"bot": None}
+
+    # Wrong key: refused, blobs still intact, report still open.
+    req.json = AsyncMock(return_value={"image_key": "nope"})
+    with pytest.raises(web.HTTPBadRequest):
+        await server.api_cancel(req)
+    assert len(abuse.report_blobs(result.report_uuid)) == 2
+    assert abuse.get_report(result.report_uuid)["status"] == abuse.REPORT_READY
+
+    # Right key: files come back, blobs purged.
+    req.json = AsyncMock(return_value={"image_key": result.p1})
+    await server.api_cancel(req)
+    assert (updir / "F0.jpg").read_bytes() == b"img-F0"
+    assert (updir / "F1.jpg").read_bytes() == b"img-F1"
+    assert abuse.report_blobs(result.report_uuid) == []
 
 
 def test_filing_clears_unselected_files(env):

--- a/tests/test_abuse_server.py
+++ b/tests/test_abuse_server.py
@@ -157,6 +157,40 @@ async def test_cancel_purges_blobs_but_keeps_files_and_relation(abuse, monkeypat
     assert abuse.get_user(1) is not None
 
 
+def test_finish_moves_reported_ciphertext_into_the_db(abuse, monkeypatch, tmp_path):
+    """Filing is what earns a place in SQLite: disk ciphertext -> DB, dir purged."""
+    from reverse_image_search_bot import settings
+    from reverse_image_search_bot.abuse_report import prepare, server
+
+    updir = tmp_path / "uploads"
+    updir.mkdir()
+    monkeypatch.setattr(settings, "UPLOADER", {"uploader": "local", "configuration": {"path": str(updir)}})
+    monkeypatch.setattr(settings, "REPORT_BASE_URL", "https://ris.naa.gg")
+
+    abuse.record_user(1)
+    for fid in ("A", "B"):
+        abuse.record_file(fid, saved_filename=f"{fid}.jpg", user_id=1, file_type="photo")
+        (updir / f"{fid}.jpg").write_bytes(b"bytes-" + fid.encode())
+    result = prepare.prepare_report(1)
+    uuid = result.report_uuid
+
+    # Nothing in the DB yet — ciphertext is on disk only.
+    assert all(bytes(b["ciphertext"]) == b"" for b in abuse.report_blobs(uuid))
+    cdir = updir / "report_files" / uuid
+    assert len(list(cdir.iterdir())) == 2
+
+    ids = {m["file_unique_id"]: m["id"] for m in abuse.blob_meta(uuid)}
+    abuse.set_blob_selection(uuid, {ids["A"]: "A1"})
+    server._cleanup_after_finish(abuse.get_report(uuid))
+
+    kept = abuse.report_blobs(uuid)
+    assert [b["file_unique_id"] for b in kept] == ["A"]
+    # The reported blob now carries its bytes in the DB and no disk dependency.
+    assert bytes(kept[0]["ciphertext"]) != b""
+    assert kept[0]["cipher_path"] is None
+    assert not cdir.exists()  # whole ciphertext dir gone
+
+
 def test_cleanup_after_finish_keeps_reported_purges_unselected(abuse, monkeypatch, tmp_path):
     """On finish: the reported files' blobs are KEPT, everything else is purged.
 

--- a/tests/test_abuse_server.py
+++ b/tests/test_abuse_server.py
@@ -117,17 +117,16 @@ async def test_select_persists(abuse, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_cancel_purges_blobs_but_keeps_files_and_relation(abuse, monkeypatch, tmp_path):
-    """Cancel = user did nothing wrong: keep disk files + filename->user relation.
+    """Cancel = user did nothing wrong: restore the files + keep the relation.
 
-    Only the encrypted blobs and the report status change; the original file on
-    disk and the files-table row (find_user_by_filename) must survive.
+    Preparing took the plaintext off disk, so cancelling must decrypt it back;
+    the files-table row (find_user_by_filename) must survive too.
     """
     from reverse_image_search_bot import settings
-    from reverse_image_search_bot.abuse_report import server
+    from reverse_image_search_bot.abuse_report import crypto, server
 
     updir = tmp_path / "uploads"
     updir.mkdir()
-    (updir / "A.jpg").write_bytes(b"plaintext image")
     monkeypatch.setattr(settings, "UPLOADER", {"configuration": {"path": str(updir)}})
 
     monkeypatch.setattr(server, "_admin_from_request", lambda req: 42)
@@ -135,32 +134,39 @@ async def test_cancel_purges_blobs_but_keeps_files_and_relation(abuse, monkeypat
     # provenance relation: filename -> user
     abuse.record_file(file_unique_id="A", saved_filename="A.jpg", original_filename="orig.jpg", user_id=1)
     abuse.create_report("u", 1, "")
+    p1 = "the-image-key"
+    plaintext = b"plaintext image"
+    nonce, ct = crypto.encrypt_file(plaintext, crypto.derive_key(p1))
     abuse.add_report_blob(
-        "u", file_unique_id="A", saved_filename="A.jpg", nonce=b"n", ciphertext=b"c", plaintext_sha256="1"
+        "u",
+        file_unique_id="A",
+        saved_filename="A.jpg",
+        nonce=nonce,
+        ciphertext=ct,
+        plaintext_sha256=crypto.sha256_hex(plaintext),
     )
-    req = _req(headers={"X-Page-Secret": "pw"}, match={"uuid": "u"})
+    req = _req(headers={"X-Page-Secret": "pw"}, match={"uuid": "u"}, json_body={"image_key": p1})
     await server.api_cancel(req)
 
     # report cancelled, blobs gone
     assert abuse.get_report("u")["status"] == abuse.REPORT_CANCELLED
     assert abuse.blob_meta("u") == []
-    # BUT: disk file kept, filename->user relation kept, user kept
-    assert (updir / "A.jpg").exists()
+    # BUT: disk file restored, filename->user relation kept, user kept
+    assert (updir / "A.jpg").read_bytes() == plaintext
     assert abuse.find_user_by_filename("A.jpg") == 1
     assert abuse.get_user(1) is not None
 
 
 def test_cleanup_after_finish_keeps_reported_purges_unselected(abuse, monkeypatch, tmp_path):
-    """On finish: reported files' plaintext deleted from disk, their blobs KEPT;
-    non-reported files' blobs purged, their disk plaintext left alone.
+    """On finish: the reported files' blobs are KEPT, everything else is purged.
+
+    No plaintext is on disk at this point — preparing the report removed it.
     """
     from reverse_image_search_bot import settings
     from reverse_image_search_bot.abuse_report import server
 
     updir = tmp_path / "uploads"
     updir.mkdir()
-    (updir / "A.jpg").write_bytes(b"reported image")
-    (updir / "B.jpg").write_bytes(b"not reported image")
     monkeypatch.setattr(settings, "UPLOADER", {"configuration": {"path": str(updir)}})
 
     abuse.record_user(1)
@@ -178,12 +184,11 @@ def test_cleanup_after_finish_keeps_reported_purges_unselected(abuse, monkeypatc
     rep = abuse.get_report("u")
     server._cleanup_after_finish(rep)
 
-    # A: plaintext deleted from disk, encrypted blob KEPT
-    assert not (updir / "A.jpg").exists()
+    # A (reported): its encrypted blob is KEPT
     kept = {b["file_unique_id"] for b in abuse.report_blobs("u")}
     assert kept == {"A"}
-    # B: blob purged, disk plaintext left untouched (not part of the report)
-    assert (updir / "B.jpg").exists()
+    # Nothing of this round is left on disk.
+    assert list(updir.iterdir()) == []
     # user + report survive
     assert abuse.get_user(1) is not None
     assert abuse.get_report("u") is not None


### PR DESCRIPTION
## Summary

Preparing a report now **takes the user's files offline**. Every on-disk file is encrypted and its plaintext deleted, so nothing of theirs is publicly reachable while a report is open. The ciphertext is the only copy.

**The ciphertext lives on disk** (`report_files/<uuid>/`), not in SQLite. Only files that actually get **filed** enter the DB — on finish the reported bytes move into the blob row and the whole on-disk directory is purged. A cancelled or abandoned round leaves nothing behind in the database.

| step | plaintext | ciphertext |
|---|---|---|
| **prepare** | all deleted | written to disk, row points at it |
| **cancel** | decrypted back onto disk | deleted (blobs purged) |
| **file** | already gone | reported → **into the DB**; rest deleted |
| **ban** | all deleted | open rounds deleted; filed reports untouched |

## Progress during preparation

A user or group with many uploads takes a while, so `prepare_report` takes an optional `(done, total)` callback:

- **`/report`** live-edits its status message (`⏳ encrypting 40/300…`), throttled to every 10th file. Encryption runs in a worker thread, so the callback schedules the edit back onto the loop with `run_coroutine_threadsafe` and never blocks.
- **The console** polls `GET /report/console/api/prepare_progress?target=…` once a second while its create request is still in flight (the create itself blocks until the round is done).

## Notable

- **`/api/cancel` now requires `image_key` (P1).** The plaintext only exists inside the blobs, so restoring needs the key. The restore verifies P1 against *every* blob's hash before writing anything — a wrong key aborts with nothing written to the upload dir and the report still open/recoverable.
- **Losing P1 now loses the files**, not just the thumbnails. The `/report` DM copy says so explicitly.
- **The 25-file batch cap is gone** — `PREPARE_BATCH`, `extend_report`, `pending_files`, `PrepareResult.remaining`, `POST /api/extend` and the webview's "Show more". A cap would leave files 26+ still served while the report is open, which defeats the point.
- `_encrypt_and_remove` unlinks each plaintext **after** its blob commits, so a crash mid-round leaves the file on disk rather than losing it.
- `_cleanup_after_finish` no longer deletes plaintext (it left at prepare time); it moves the reported ciphertext into the DB, purges every non-reported blob plus its video ciphertext, then drops the report's cipher directory.
- Reported **videos** keep their encrypted file on disk — far too large for SQLite. That's the pre-existing design, unchanged.

## Test plan

- [x] `pytest` — 558 passed
- [x] `uvx ruff@latest check .` — clean
- [x] `uvx ruff@latest format --check` — clean
- [x] `node --check` on both webview scripts
- [x] Behaviour check on the cancel handler, lifted verbatim from `report.html`: refuses without P1, sends `image_key` + `clear_files` when given one
- [x] New tests: prepare removes all plaintext and keeps ciphertext on disk (not in the DB), restore round-trips, restore with a wrong key writes nothing, `delete_user_files` scoped to one user, cancel restores + rejects a wrong key, filing moves ciphertext into the DB and purges the dir, ban wipes an open round's ciphertext but leaves a filed report intact, prepare emits `(done, total)` progress

No NCMEC calls were made; `finish()` was not exercised.
